### PR TITLE
feat: add `validate` mode to run validation on the configuration file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,16 +27,40 @@ jobs:
             - name: Install dependencies
               run: go mod download
 
-            - name: Lint (golangci-lint)
+            - name: Install golangci-lint
               uses: golangci/golangci-lint-action@v8
               with:
                   version: v2.4.0
-                  args: >
-                      --timeout=5m
+                  args: --help
 
-            - name: Build
-              run: go build -v ./...
+            - name: Install GoReleaser
+              uses: goreleaser/goreleaser-action@v6
+              with:
+                  version: 2.11.2
+                  install-only: true
 
-            - name: Test
+            - uses: actions/setup-python@v5
+              name: Install python
+              with:
+                  python-version: 3.9
+                  cache: pip
+
+            - run: pip install -r requirements.txt
+              name: Install python dependencies
+
+            - uses: pre-commit/action@v3.0.1
+              name: Run pre-commit
+
+            - name: Format
               run: |
-                  go test -v ./...
+                  make fmt
+                  git diff --exit-code || (echo "Code is not formatted, run 'make fmt' locally" && exit 1)
+
+            - name: Lint
+              run: make lint
+
+            - name: Unit tests
+              run: make test/unit
+
+            - name: Integration tests
+              run: make test/integration

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ In `~/.config/hyprdynamicmonitors/config.toml` (assuming you have `eDP-1` displa
 [general]
 destination = "$HOME/.config/hypr/monitors.conf"
 
+[power_events]
+
+[power_events.dbus_query_object]
+# path to your line_power upower device
+path = "/org/freedesktop/UPower/devices/line_power_ACAD"
+
+[[power_events.dbus_signal_match_rules]]
+# path to your line_power upower device
+object_path = "/org/freedesktop/UPower/devices/line_power_ACAD"
+
 [profiles.laptop_only]
 config_file = "hyprconfigs/laptop.conf"
 config_file_type = "static"
@@ -172,10 +182,15 @@ timeout_ms = 3000    # 3 seconds
 
 ### Command Line
 
-```bash
-hyprdynamicmonitors [options]
+```text
 
-Usage of hyprdynamicmonitors:
+Usage: hyprdynamicmonitors [options] [command]
+
+Commands:
+  run      Run the service (default)
+  validate Validate configuration file and exit
+
+Options:
   -config string
         Path to configuration file (default "$HOME/.config/hyprdynamicmonitors/config.toml")
   -debug
@@ -190,6 +205,18 @@ Usage of hyprdynamicmonitors:
         Enable verbose logging
   -version
         Show version information
+```
+
+**Validate configuration:**
+```bash
+# Validate default config file
+hyprdynamicmonitors validate
+
+# Validate specific config file
+hyprdynamicmonitors -config /path/to/config.toml validate
+
+# Validate with debug output
+hyprdynamicmonitors -debug validate
 ```
 
 ### Hyprland Integration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,7 +136,7 @@ func TestLoad(t *testing.T) {
 			name:          "invalid - no profiles",
 			configFile:    "invalid_no_profiles.toml",
 			expectError:   true,
-			errorContains: "no profiles defined",
+			errorContains: "at least one profile has to be defined",
 		},
 		{
 			name:          "invalid - missing config file",
@@ -148,7 +148,7 @@ func TestLoad(t *testing.T) {
 			name:          "invalid - no required monitors",
 			configFile:    "invalid_no_monitors.toml",
 			expectError:   true,
-			errorContains: "at least one required_monitor must be specified",
+			errorContains: "at least one required_monitors must be specified",
 		},
 		{
 			name:          "invalid - monitor without name or description",

--- a/internal/hypr/ipc_test.go
+++ b/internal/hypr/ipc_test.go
@@ -13,12 +13,10 @@ import (
 
 	"github.com/fiffeek/hyprdynamicmonitors/internal/hypr"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestIPC_Run(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
 	tests := []struct {
 		name               string
 		mockEvents         []string
@@ -128,7 +126,12 @@ func TestIPC_Run(t *testing.T) {
 			}
 
 			xdgRuntimeDir, signature := setupEnvVars(t)
-			eventsListener, eventsSocketCleanUp := setupSocket(ctx, t, xdgRuntimeDir, signature, hypr.GetHyprEventsSocket)
+			eventsListener, eventsSocketCleanUp := setupSocket(
+				ctx,
+				t,
+				xdgRuntimeDir,
+				signature,
+				hypr.GetHyprEventsSocket)
 			ipcListener, ipcCleanUp := setupSocket(ctx, t, xdgRuntimeDir, signature, hypr.GetHyprSocket)
 			writerDone := setupFakeHyprIPCWriter(t, ipcListener, responseData, tt.expectedCommands, tt.exitOnError)
 			ipc, err := hypr.NewIPC()

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -1,0 +1,15 @@
+package utils
+
+import "strings"
+
+type HasValue interface {
+	Value() string
+}
+
+func FormatEnumTypes[T HasValue](enums []T) string {
+	mapped := []string{}
+	for _, configFileType := range enums {
+		mapped = append(mapped, configFileType.Value())
+	}
+	return "[" + strings.Join(mapped, ", ") + "]"
+}

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -1,0 +1,60 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const (
+	binaryPathEnvVar = "HDM_BINARY_PATH"
+)
+
+var (
+	_, b, _, _ = runtime.Caller(0)
+	basepath   = filepath.Dir(filepath.Dir(b))
+	binaryPath = ""
+)
+
+func runBinary(ctx context.Context, args []string) ([]byte, error) {
+	// nolint:gosec
+	cmd := exec.CommandContext(
+		ctx,
+		filepath.Join(basepath, binaryPath),
+		args...)
+	cmd.Env = append(os.Environ(), "GOCOVERDIR=.coverdata")
+	// nolint:wrapcheck
+	return cmd.CombinedOutput()
+}
+
+func find(root, ext string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(s string, d fs.DirEntry, e error) error {
+		if e != nil {
+			return e
+		}
+		if filepath.Ext(d.Name()) == ext {
+			files = append(files, s)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cant walk dir: %w", err)
+	}
+	return files, nil
+}
+
+func TestMain(m *testing.M) {
+	binaryPath = os.Getenv(binaryPathEnvVar)
+	if binaryPath == "" {
+		fmt.Printf("no binary provided")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}

--- a/test/validate_test.go
+++ b/test/validate_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var examples = filepath.Join(basepath, "examples")
+
+func Test_Validate_Examples(t *testing.T) {
+	files, err := find(examples, ".toml")
+	require.NoError(t, err, "didnt find all example configs")
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			defer cancel()
+
+			done := make(chan any, 1)
+			defer close(done)
+
+			go func() {
+				out, err := runBinary(ctx, []string{"--config", file, "validate"})
+				require.NoError(t, err, "binary failed %s", string(out))
+				done <- true
+			}()
+
+			select {
+			case <-ctx.Done():
+				require.NoError(t, ctx.Err(), "timeout")
+			case <-done:
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

* add `validate` mode to run validation on the configuration file
* improve ci to run make targets
* install python and pre-commit in ci

## Why is this change important?

allows users to run validate on configurations prior to running the cli

## How to test this PR locally?

`make test/unit && make test/integration`
