### PR TITLE
docs: auto-generate toc on pre-commit hooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,9 @@ jobs:
                   python-version: 3.9
                   cache: pip
 
+            - run: make install/.toc.stamp
+              name: Install gh-md-toc
+
             - run: pip install -r requirements.txt
               name: Install python dependencies
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ main
 # Added by goreleaser init:
 dist/
 node_modules/
+bin/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,8 @@ repos:
             stages: [commit-msg]
             entry: npx commitlint --edit
             language: system
+          - id: autotoc
+            name: generate toc
+            entry: ./scripts/autotoc.sh
+            language: system
+            files: ^README\.md$

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ GORELEASER_BIN := goreleaser
 DESTDIR ?= $(HOME)/.local/bin
 EXECUTABLE_NAME := hyprdynamicmonitors
 TEST_EXECUTABLE_NAME := ./dist/hdmtest
+GH_MD_TOC_FILE := "https://raw.githubusercontent.com/ekalinin/github-markdown-toc/master/gh-md-toc"
+DEV_BINARIES_DIR := "./bin"
+GH_MD_TOC_BIN := "gh-md-toc"
 
 .PHONY: install test fmt lint release/local
 
@@ -43,7 +46,16 @@ dev: \
 	$(INSTALL_DIR)/.asdf.stamp \
 	$(INSTALL_DIR)/.venv.stamp \
 	$(INSTALL_DIR)/.npm.stamp \
-	$(INSTALL_DIR)/.precommit.stamp
+	$(INSTALL_DIR)/.precommit.stamp \
+	$(INSTALL_DIR)/.toc.stamp
+
+$(INSTALL_DIR)/.toc.stamp: $(INSTALL_DIR)/.dir.stamp
+	@mkdir -p $(DEV_BINARIES_DIR)
+	@wget -q $(GH_MD_TOC_FILE)
+	@chmod 755 $(GH_MD_TOC_BIN)
+	@mv $(GH_MD_TOC_BIN) $(DEV_BINARIES_DIR)
+	@$(DEV_BINARIES_DIR)/$(GH_MD_TOC_BIN) --help >/dev/null
+	@touch $@
 
 $(INSTALL_DIR)/.dir.stamp:
 	@mkdir -p $(INSTALL_DIR)

--- a/scripts/autotoc.sh
+++ b/scripts/autotoc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+README="README.md"
+
+"${SCRIPT_DIR}/../bin/gh-md-toc" --no-backup --hide-footer "$README"


### PR DESCRIPTION
## What does this PR do?

Run gh-md-toc on precommit hooks

## Why is this change important?

README grew a bit, would be great to have easy to access sections