### PR TITLE
feat(nix): add a flake for nix installs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,9 @@ on:
             - main
 
 jobs:
-    ci:
+    tests:
         runs-on: ubuntu-latest
-        timeout-minutes: 20
+        timeout-minutes: 5
 
         steps:
             - name: Checkout
@@ -67,3 +67,21 @@ jobs:
 
             - name: Integration tests
               run: make test/integration
+
+    nix:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - uses: DeterminateSystems/nix-installer-action@main
+
+            - uses: DeterminateSystems/magic-nix-cache-action@main
+
+            - name: Test Nix build
+              run: |
+                  nix flake check
+                  nix build
+                  ./result/bin/hyprdynamicmonitors --version

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ main
 dist/
 node_modules/
 bin/
+result

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An event-driven service that automatically manages Hyprland monitor configuratio
    * [Installation](#installation)
       * [Binary Release](#binary-release)
       * [AUR](#aur)
+      * [Nix](#nix)
       * [Build from Source](#build-from-source)
    * [Usage](#usage)
       * [Command Line](#command-line)
@@ -113,6 +114,21 @@ $aurHelper -S hyprdynamicmonitors-bin
 git clone https://aur.archlinux.org/hyprdynamicmonitors-bin.git
 cd hyprdynamicmonitors-bin
 makepkg -si
+```
+
+### Nix
+
+For Nix and NixOS users:
+
+```bash
+# Run directly from GitHub
+nix run github:fiffeek/hyprdynamicmonitors
+
+# Or from specific tag/version (recommended)
+nix run github:fiffeek/hyprdynamicmonitors/v1.0.0
+
+# Install to profile
+nix profile install github:fiffeek/hyprdynamicmonitors
 ```
 
 ### Build from Source

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Dynamic monitor configuration for Hyprland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        version = if self ? rev then "git-${builtins.substring 0 7 (toString self.rev)}" else "dev";
+
+        hyprdynamicmonitors = pkgs.buildGoModule {
+          pname = "hyprdynamicmonitors";
+          inherit version;
+
+          src = ./.;
+          vendorHash = "sha256-irbpDD7hn2SWDQNtRE5TzkqklXyx03ie8dSF+6SR50A=";
+
+          subPackages = [ "." ];
+
+          ldflags = [
+            "-s" "-w"
+            "-X github.com/fiffeek/hyprdynamicmonitors/cmd.Version=${version}"
+            "-X github.com/fiffeek/hyprdynamicmonitors/cmd.Commit=${self.rev or "unknown"}"
+            "-X github.com/fiffeek/hyprdynamicmonitors/cmd.BuildDate=${self.lastModifiedDate or "1970-01-01T00:00:00Z"}"
+          ];
+
+          nativeBuildInputs = [ pkgs.installShellFiles ];
+
+          postInstall = ''
+            installShellCompletion --cmd hyprdynamicmonitors \
+              --bash <($out/bin/hyprdynamicmonitors completion bash) \
+              --fish <($out/bin/hyprdynamicmonitors completion fish) \
+              --zsh <($out/bin/hyprdynamicmonitors completion zsh)
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Dynamic monitor configuration for Hyprland";
+            homepage = "https://github.com/fiffeek/hyprdynamicmonitors";
+            license = licenses.mit;
+            platforms = platforms.linux;
+            mainProgram = "hyprdynamicmonitors";
+          };
+        };
+      in
+      {
+        packages.default = hyprdynamicmonitors;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = hyprdynamicmonitors;
+        };
+      });
+}


### PR DESCRIPTION
## What does this PR do?

Add a flake (with a lock) so that the package can be built by nix, users still need to write their own systemd service and depend on this flake.

## How to test this PR locally?

```
nix --extra-experimental-features "nix-command flakes" run github:fiffeek/hyprdynamicmonitors/u/fm/nix -- --help
HyprDynamicMonitors is a service that automatically switches between predefined Hyprland monitor configuration profiles based on connected monitors and power state.

Usage:
  hyprdynamicmonitors [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  freeze      Freeze current monitor configuration as a new profile template
  help        Help about any command
  run         Run the monitor configuration service
  validate    Validate configuration file

Flags:
      --config string             Path to configuration file (default "$HOME/.config/hyprdynamicmonitors/config.toml")
      --debug                     Enable debug logging
      --enable-json-logs-format   Enable structured logging
  -h, --help                      help for hyprdynamicmonitors
      --verbose                   Enable verbose logging
  -v, --version                   version for hyprdynamicmonitors

Use "hyprdynamicmonitors [command] --help" for more information about a command.
```

Seems building the package and running works.

## Related issues
Closes #9 
