### PR TITLE
fix(matchers): ensure both desc/name match when provided

### DIFF
--- a/internal/matchers/matcher.go
+++ b/internal/matchers/matcher.go
@@ -69,6 +69,12 @@ func (m *Matcher) scoreProfile(cfg *config.RawConfig, conditions *config.Profile
 
 	for _, condition := range conditions.RequiredMonitors {
 		for _, connectedMonitor := range connectedMonitors {
+			// if both are defined but there is a mismatch on either then skip
+			if condition.Name != nil && condition.Description != nil &&
+				(*condition.Name != connectedMonitor.Name ||
+					*condition.Description != connectedMonitor.Description) {
+				continue
+			}
 			if condition.Name != nil && *condition.Name == connectedMonitor.Name {
 				profileScore += *cfg.Scoring.NameMatch
 			}

--- a/internal/matchers/matcher_test.go
+++ b/internal/matchers/matcher_test.go
@@ -255,6 +255,29 @@ func TestMatcher_Match(t *testing.T) {
 			expectedProfile: "",
 			description:     "Should return no match when no profile matches and no fallback is configured",
 		},
+		{
+			name: "both_name_and_description_must_match_same_monitor",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"strict_match": {
+					Name: "strict_match",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("External Monitor"),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Profile should not match when name comes from one monitor and description from another",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does this PR do?

Simple bugfix + test for this scenario, occurred while testing a new TUI.

## Related issues

<!--
Closes #234
-->
