### PR TITLE
fix: init profilemaker for tui when no hypr monitors are not overwritten

### DIFF
--- a/internal/app/tui.go
+++ b/internal/app/tui.go
@@ -55,6 +55,7 @@ func NewTUI(ctx context.Context, configPath, mockedHyprMonitors string,
 		}
 
 		monitors = hyprIPC.GetConnectedMonitors()
+		profileMaker = profilemaker.NewService(cfg, hyprIPC)
 	}
 
 	if err := monitors.Validate(); err != nil {


### PR DESCRIPTION
## What does this PR do?

Profile maker was only init when hypr monitors were overwritten (which was true for all UI tests, hence not caught), needs integ tests but these will come later.


## Related issues

Closes #23 
