### PR TITLE
docs: add missing params explanations for config options

### DIFF
--- a/docs/docs/configuration/lid-events.md
+++ b/docs/docs/configuration/lid-events.md
@@ -54,6 +54,8 @@ dbus-send --system --print-reply \
 
 ## Custom D-Bus Configuration
 
+### Custom Signal Match Rules
+
 You can customize which D-Bus signals to monitor for lid events:
 
 ```toml
@@ -62,10 +64,34 @@ You can customize which D-Bus signals to monitor for lid events:
 interface = "org.freedesktop.DBus.Properties"
 member = "PropertiesChanged"
 object_path = "/org/freedesktop/UPower"
+# sender = "org.freedesktop.UPower"  # Optional: specific sender
 
 [[lid_events.dbus_signal_receive_filters]]
 name = "org.freedesktop.DBus.Properties.PropertiesChanged"
+body = "LidIsClosed"  # Filter signals containing this in the body
 ```
+
+The `body` filter is useful for limiting the signals processed, as D-Bus property change events can be noisy.
+
+### Custom Query Configuration
+
+You can customize how lid state is queried:
+
+```toml
+[lid_events.dbus_query_object]
+destination = "org.freedesktop.UPower"
+path = "/org/freedesktop/UPower"
+method = "org.freedesktop.DBus.Properties.Get"
+expected_lid_closing_value = "true"
+
+[[lid_events.dbus_query_object.args]]
+arg = "org.freedesktop.UPower"
+
+[[lid_events.dbus_query_object.args]]
+arg = "LidIsClosed"
+```
+
+This configuration is equivalent to the default and queries the lid state using standard UPower D-Bus properties.
 
 See the [lid-states example](https://github.com/fiffeek/hyprdynamicmonitors/tree/main/examples/lid-states) for a complete configuration.
 

--- a/docs/docs/configuration/monitor-matching.md
+++ b/docs/docs/configuration/monitor-matching.md
@@ -87,6 +87,22 @@ name = "eDP-1"
 
 When only `eDP-1` is connected, both profiles match, but `laptop_optimized` is selected because it's defined last.
 
+### Customizing Scoring Weights
+
+You can customize the scoring weights to prioritize different matching criteria:
+
+```toml
+[scoring]
+name_match = 10       # Points for exact monitor name match
+description_match = 5 # Points for exact monitor description match
+power_state_match = 3 # Bonus points for matching power state
+lid_state_match = 2   # Bonus points for matching lid state
+```
+
+Higher values give more weight to specific criteria. For example, if you want power state matching to have more influence, increase the `power_state_match` value.
+
+See [Configuration Overview](./overview#scoring) for more details.
+
 ## Best Practices
 
 1. **Order matters**: Define more generic profiles first, specific ones last

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -24,9 +24,17 @@ The configuration file is written in TOML and consists of several main sections:
 ```toml
 [general]
 destination = "$HOME/.config/hypr/monitors.conf"
+debounce_time_ms = 1500
+pre_apply_exec = "notify-send 'Switching profile...'"
+post_apply_exec = "notify-send 'Profile applied'"
 ```
 
-The `destination` specifies where the monitor configuration file will be created or linked.
+- `destination` - Where the monitor configuration file will be created or linked
+- `debounce_time_ms` - Collect events for this duration before applying changes (prevents configuration thrashing, default: 1500ms)
+- `pre_apply_exec` - Command to run before applying configuration (optional)
+- `post_apply_exec` - Command to run after applying configuration (optional)
+
+See [Callbacks](./callbacks) for details on exec commands.
 
 ### Power Events
 
@@ -77,6 +85,53 @@ timeout_ms = 10000
 ```
 
 Configure desktop notifications for configuration changes. See [Notifications](./notifications).
+
+### Hot Reload
+
+```toml
+[hot_reload_section]
+debounce_time_ms = 1000
+```
+
+Hot reload watches configuration files for changes and automatically reloads them. The `debounce_time_ms` setting controls how long to wait before applying changes after detecting a file modification.
+
+### Scoring
+
+```toml
+[scoring]
+name_match = 10
+description_match = 5
+power_state_match = 3
+lid_state_match = 2
+```
+
+Customize the scoring system for profile selection when multiple profiles match. Higher scores win:
+- `name_match` - Points for exact monitor name match (e.g., "eDP-1")
+- `description_match` - Points for exact monitor description match
+- `power_state_match` - Bonus points for matching power state
+- `lid_state_match` - Bonus points for matching lid state
+
+See [Monitor Matching](./monitor-matching) for details on how profiles are selected.
+
+### Static Template Values
+
+```toml
+[static_template_values]
+default_vrr = "1"
+default_res = "2880x1920"
+```
+
+Define global values that can be used in all templates. These can be overridden per-profile. See [Templates](../advanced/templates) and [Profiles](./profiles) for details.
+
+### Fallback Profile
+
+```toml
+[fallback_profile]
+config_file = "hyprconfigs/fallback.conf"
+config_file_type = "static"
+```
+
+Define a fallback profile that will be used when no other profile matches the current state. See [Profiles](./profiles) for details.
 
 ## Next Steps
 

--- a/docs/docs/configuration/power-events.md
+++ b/docs/docs/configuration/power-events.md
@@ -63,7 +63,10 @@ You can customize which D-Bus signals to monitor and how to query power status.
 interface = "org.freedesktop.DBus.Properties"
 member = "PropertiesChanged"
 object_path = "/org/freedesktop/UPower/devices/line_power_ACAD"
+# sender = "org.freedesktop.UPower"  # Optional: specific sender
 ```
+
+You can add multiple match rules to listen for different events like `DeviceAdded` and `DeviceRemoved`.
 
 ### Custom Signal Filters
 


### PR DESCRIPTION
## What does this PR do?

Adds missing docs on config options.

## Related issues

#38 
