### PR TITLE
fix(hypr): allow for empty monitor description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ build/test:
 test/integration: build/test
 	@rm -rf .coverdata
 	@mkdir -p .coverdata
-	@HDM_BINARY_PATH=$(TEST_EXECUTABLE_NAME) $(GOTESTSUMINTEGRATION) -- -v ./test/... --debug --count=1
+	@HDM_BINARY_PATH=$(TEST_EXECUTABLE_NAME) $(GOTESTSUMINTEGRATION) --rerun-fails=2 --packages="./test/..." -- -v ./test/... --debug --count=1
 	@$(GOLANG_BIN) tool covdata textfmt -i=.coverdata -o=integration.txt
 
 test/integration/regenerate: build/test

--- a/docs/docs/configuration/monitor-matching.md
+++ b/docs/docs/configuration/monitor-matching.md
@@ -6,6 +6,10 @@ sidebar_position: 2
 
 Profiles match monitors based on their properties. Understanding how monitor matching works is essential for creating effective profiles.
 
+:::tip
+For fake outputs (headless displays) the description from `hyprctl` will be empty so use the `name` matcher.
+:::
+
 ## Matching Properties
 
 You can match monitors by:

--- a/internal/hypr/ipc_test.go
+++ b/internal/hypr/ipc_test.go
@@ -400,22 +400,24 @@ func TestIPC_GetConnectedMonitors(t *testing.T) {
 			description: "Should successfully parse valid monitor response",
 		},
 		{
-			name:          "missing_description",
-			responseFile:  "testdata/monitors_response_missing_description.json",
-			expectedError: "failed to validate response: invalid monitor: desc cant be empty",
-			description:   "Should fail when monitor block is missing description",
+			name:         "missing_description",
+			responseFile: "testdata/monitors_response_missing_description.json",
+			description:  "Should succeed when monitor block is missing description (this is the case for virtual/headless outputs)",
+			expectedMonitors: []*hypr.MonitorSpec{
+				{
+					Name:          "eDP-1",
+					ID:            utils.IntPtr(0),
+					Description:   "",
+					SdrBrightness: 1,
+					SdrSaturation: 1,
+				},
+			},
 		},
 		{
 			name:          "malformed_header",
 			responseFile:  "testdata/monitors_response_malformed_header.json",
 			expectedError: "failed to validate response: invalid monitor: id cant be nil",
 			description:   "Should fail when monitor header has wrong number of parts",
-		},
-		{
-			name:          "malformed_description",
-			responseFile:  "testdata/monitors_response_malformed_description.json",
-			expectedError: "failed to validate response: invalid monitor: desc cant be empty",
-			description:   "Should fail when description line has wrong format",
 		},
 	}
 

--- a/internal/hypr/testdata/monitors_response_malformed_description.json
+++ b/internal/hypr/testdata/monitors_response_malformed_description.json
@@ -1,7 +1,0 @@
-[
-  {
-    "description": null,
-    "id": 0,
-    "name": "eDP-1"
-  }
-]

--- a/internal/hypr/testdata/monitors_response_missing_description.json
+++ b/internal/hypr/testdata/monitors_response_missing_description.json
@@ -1,5 +1,6 @@
 [
   {
+    "description": "",
     "id": 0,
     "name": "eDP-1"
   }

--- a/internal/hypr/types.go
+++ b/internal/hypr/types.go
@@ -65,11 +65,11 @@ func (m *MonitorSpec) Validate() error {
 	if *m.ID < 0 {
 		return errors.New("id cant < 0")
 	}
-	if m.Description == "" {
-		return errors.New("desc cant be empty")
-	}
 	if m.Name == "" {
 		return errors.New("name cant be empty")
+	}
+	if m.Description == "" {
+		logrus.WithFields(logrus.Fields{"id": m.ID, "name": m.Name}).Warning("Monitor description is empty")
 	}
 	if !m.TenBitdepth {
 		m.TenBitdepth = m.IsTenBitdepth()

--- a/internal/profilemaker/service_test.go
+++ b/internal/profilemaker/service_test.go
@@ -1,6 +1,7 @@
 package profilemaker_test
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var regenerate = flag.Bool("regenerate", false, "regenerate fixtures instead of comparing")
 
 func TestService_EditExisting(t *testing.T) {
 	// Sample monitors data
@@ -48,6 +51,18 @@ func TestService_EditExisting(t *testing.T) {
 			ColorPreset:   "hdr",
 			SdrBrightness: 1.1,
 			SdrSaturation: 0.98,
+		},
+		{
+			ID:          utils.IntPtr(3),
+			Name:        "monC",
+			Description: "",
+			Width:       1000,
+			Height:      1000,
+			RefreshRate: 60.0,
+			X:           -1000,
+			Y:           -1000,
+			Scale:       1.0,
+			Transform:   0,
 		},
 	}
 
@@ -175,23 +190,7 @@ func TestService_EditExisting(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			// nolint:gosec
-			resultContent, err := os.ReadFile(configFile)
-			require.NoError(t, err)
-
-			// nolint:gosec
-			expectedContent, err := os.ReadFile(tc.expectedFile)
-			require.NoError(t, err)
-
-			actualOutput := strings.TrimSpace(string(resultContent))
-			expectedOutput := strings.TrimSpace(string(expectedContent))
-
-			assert.Equal(t, expectedOutput, actualOutput)
-
-			if !tc.expectError {
-				assert.Contains(t, string(resultContent), "# <<<<< TUI AUTO START")
-				assert.Contains(t, string(resultContent), "# <<<<< TUI AUTO END")
-			}
+			testutils.AssertFixture(t, configFile, tc.expectedFile, *regenerate)
 		})
 	}
 }

--- a/internal/profilemaker/testdata/expected_append_broken_markers.conf
+++ b/internal/profilemaker/testdata/expected_append_broken_markers.conf
@@ -9,4 +9,5 @@ bind = $mainMod, Q, exec, kitty
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_append_no_markers.conf
+++ b/internal/profilemaker/testdata/expected_append_no_markers.conf
@@ -7,4 +7,5 @@ bind = $mainMod, C, killactive
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_empty_config.conf
+++ b/internal/profilemaker/testdata/expected_empty_config.conf
@@ -1,4 +1,5 @@
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_markers_only.conf
+++ b/internal/profilemaker/testdata/expected_markers_only.conf
@@ -1,4 +1,5 @@
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_non_existent.conf
+++ b/internal/profilemaker/testdata/expected_non_existent.conf
@@ -1,4 +1,5 @@
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_replace_markers.conf
+++ b/internal/profilemaker/testdata/expected_replace_markers.conf
@@ -4,6 +4,7 @@ source = ~/.config/hypr/monitors.conf
 # <<<<< TUI AUTO START
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
+monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
 # <<<<< TUI AUTO END
 
 

--- a/internal/tui/monitor_editor.go
+++ b/internal/tui/monitor_editor.go
@@ -432,6 +432,7 @@ func (e *MonitorEditorStore) snapToEdges(monitorIndex, x, y int) (int, int, tea.
 
 func (e *MonitorEditorStore) FindByID(monitorID int) (*MonitorSpec, int, error) {
 	for index, monitor := range e.monitors {
+		logrus.WithFields(logrus.Fields{"current": monitorID, "new": *monitor.ID}).Debug("Comparing monitors")
 		if *monitor.ID == monitorID {
 			return monitor, index, nil
 		}

--- a/internal/tui/monitor_list.go
+++ b/internal/tui/monitor_list.go
@@ -35,6 +35,10 @@ func (m MonitorItem) MonitorDescription() string {
 }
 
 func (m MonitorItem) MonitorDescriptionTrunc() string {
+	if m.monitor.Description == "" {
+		return ""
+	}
+
 	desc := m.monitor.Description
 	if len(desc) > 15 {
 		desc = desc[:15]

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -354,34 +354,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ChangeMirrorPreviewCommand:
 		logrus.Debug("Received preview change for monitor mirror")
 		cmds = append(cmds, m.monitorEditor.SetMirror(
-			m.rootState.State.MonitorEditedListIndex, msg.MirrorOf))
+			m.rootState.State.MonitorEditedID, msg.MirrorOf))
 	case NextBitdepthCommand:
 		logrus.Debug("Received next bitdepth")
 		cmds = append(cmds, m.monitorEditor.NextBitdepth(msg.MonitorID))
 	case ChangeMirrorCommand:
 		logrus.Debug("Received change for monitor mirror")
 		cmds = append(cmds, m.monitorEditor.SetMirror(
-			m.rootState.State.MonitorEditedListIndex, msg.MirrorOf))
+			m.rootState.State.MonitorEditedID, msg.MirrorOf))
 		cmds = append(cmds, m.monitorsList.Update(msg))
 	case ChangeModePreviewCommand:
 		logrus.Debug("Received preview change for monitor mode")
 		cmds = append(cmds, m.monitorEditor.SetMode(
-			m.rootState.State.MonitorEditedListIndex, msg.Mode))
+			m.rootState.State.MonitorEditedID, msg.Mode))
 	case ChangeColorPresetCommand:
 		logrus.Debug("Received change color preset")
 		cmds = append(cmds, m.monitorEditor.SetColorPreset(
-			m.rootState.State.MonitorEditedListIndex, msg.Preset))
+			m.rootState.State.MonitorEditedID, msg.Preset))
 	case ChangeColorPresetFinalCommand:
 		logrus.Debug("Received final change color preset")
 		cmds = append(cmds, m.monitorEditor.SetColorPreset(
-			m.rootState.State.MonitorEditedListIndex, msg.Preset))
+			m.rootState.State.MonitorEditedID, msg.Preset))
 		cmds = append(cmds, m.monitorsList.Update(msg))
 	case CloseMonitorModeListCommand, CloseMonitorMirrorListCommand, CloseColorPickerCommand:
 		cmds = append(cmds, m.monitorsList.Update(msg))
 	case ChangeModeCommand:
 		logrus.Debug("Received change for monitor mode")
 		cmds = append(cmds, m.monitorEditor.SetMode(
-			m.rootState.State.MonitorEditedListIndex, msg.Mode))
+			m.rootState.State.MonitorEditedID, msg.Mode))
 		cmds = append(cmds, m.monitorsList.Update(msg))
 	case CreateNewProfileCommand:
 		logrus.Debug("Received create new profile")

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -33,6 +33,7 @@ type AppState struct {
 	ColorSelection         bool
 	Fullscreen             bool
 	MonitorEditedListIndex int
+	MonitorEditedID        int
 	Snapping               bool
 	ProfileNameRequested   bool
 	ShowConfirmationPrompt bool
@@ -116,6 +117,7 @@ func (r *RootState) SetMonitorEditState(msg MonitorBeingEdited) {
 	r.State.Scaling = msg.Scaling
 	r.State.ModeSelection = msg.ModesEditor
 	r.State.MonitorEditedListIndex = msg.ListIndex
+	r.State.MonitorEditedID = msg.MonitorID
 	r.State.MirrorSelection = msg.MirroringMode
 	r.State.ColorSelection = msg.ColorSelection
 }
@@ -127,6 +129,7 @@ func (r *RootState) ClearMonitorEditState() {
 	r.State.MonitorEditedListIndex = -1
 	r.State.MirrorSelection = false
 	r.State.ColorSelection = false
+	r.State.MonitorEditedID = -1
 }
 
 func (r *RootState) CurrentView() ViewMode {

--- a/internal/tui/testdata/TestModel_Update_UserFlows/headless.golden
+++ b/internal/tui/testdata/TestModel_Update_UserFlows/headless.golden
@@ -1,0 +1,45 @@
+ HyprDynamicMonitors [v. test-version]  Monitors  Profile                                                                                                       
+╭───────────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
+│HyprDynamicMonitors Profile                        ││Profile Config Preview (template)                                                                       │ 
+│                                                   ││h.go.tmpl                                                                                               │ 
+│Profile: h                                         ││                                                                                                        │ 
+│                                                   ││┃   1 # Generated with hyprdynamicmonitors freeze.                                                      │ 
+│Profile Details                                    ││┃   2 # This is a template that you can edit, it is just a starter that pulled your current monitor     │ 
+│Config File: h.go.tmpl                             ││┃     setup,                                                                                            │ 
+│Config Type: template                              ││┃   3 # adjust as needed.                                                                               │ 
+│Required Monitors:                                 ││┃   4 # You can use templates here etc, see                                                             │ 
+│  • Name: HEADLESS-2 | Tag: monitor1               ││┃     https://github.com/fiffeek/hyprdynamicmonitors/blob/main/examples/basic/hyprconfigs/template.go.tm│ 
+│                                                   ││┃     pl.                                                                                               │ 
+│New settings will be appended when saved           ││┃   5 # Monitors are given arbitrary tags (the "monitor" prefix and the ID coming from hyprland).       │ 
+│                                                   ││┃   6 # If you are using tui to edit, leave this at the end of your file (the last monitor config       │ 
+│                                                   ││┃     applies)                                                                                          │ 
+│                                                   ││┃   7 # and leave the markers.                                                                          │ 
+│                                                   ││┃   8 # <<<<< TUI AUTO START                                                                            │ 
+│                                                   ││┃   9 monitor=HEADLESS-2,1920x1080@0.06000,2680x0,1.00,transform,0,vrr,0                                │ 
+│                                                   ││┃  10 # <<<<< TUI AUTO END                                                                              │ 
+│                                                   ││┃  11                                                                                                   │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││┃                                                                                                       │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│  n new profile • a apply monitors to existing     ││                                                                                                        │ 
+│  profile • e edit manually                        ││                                                                                                        │ 
+╰───────────────────────────────────────────────────╯╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
+  tab switch view • C edit HyprDynamicMonitors config                                                                                                           
+                                                                                                                                                                

--- a/internal/tui/testdata/headless.json
+++ b/internal/tui/testdata/headless.json
@@ -1,0 +1,59 @@
+[
+  {
+    "activeWorkspace": {
+      "id": 20,
+      "name": "20"
+    },
+    "activelyTearing": false,
+    "availableModes": [
+      "1920x1080@0.06Hz"
+    ],
+    "currentFormat": "XRGB8888",
+    "description": "",
+    "directScanoutBlockedBy": [
+      "USER",
+      "CANDIDATE"
+    ],
+    "directScanoutTo": "0",
+    "disabled": false,
+    "dpmsStatus": true,
+    "focused": false,
+    "height": 480,
+    "id": 1,
+    "make": "",
+    "mirrorOf": "none",
+    "model": "",
+    "name": "HEADLESS-2",
+    "physicalHeight": 0,
+    "physicalWidth": 0,
+    "refreshRate": 60.0,
+    "reserved": [
+      0,
+      24,
+      640,
+      480
+    ],
+    "scale": 1.0,
+    "serial": "",
+    "solitary": "0",
+    "solitaryBlockedBy": [
+      "WINDOWED",
+      "CANDIDATE"
+    ],
+    "specialWorkspace": {
+      "id": 0,
+      "name": ""
+    },
+    "tearingBlockedBy": [
+      "NOT_TORN",
+      "USER",
+      "SUPPORT",
+      "CANDIDATE"
+    ],
+    "transform": 0,
+    "vrr": false,
+    "width": 640,
+    "x": 2680,
+    "y": 0
+  }
+]

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -310,10 +310,16 @@ func (m *MonitorSpec) ToHyprMonitors() (*hypr.MonitorSpec, error) {
 }
 
 func (m *MonitorSpec) ToHypr() string {
-	if m.Disabled {
-		return fmt.Sprintf("desc:%s,disable", m.Description)
+	// desc can be empty, use the name as a fallback
+	identifier := m.Name
+	if m.Description != "" {
+		identifier = "desc:" + m.Description
 	}
-	line := fmt.Sprintf("desc:%s,%dx%d@%.2f,%dx%d,%.2f,transform,%d", m.Description, m.Width,
+	if m.Disabled {
+		// nolint:perfsprint
+		return fmt.Sprintf("%s,disable", identifier)
+	}
+	line := fmt.Sprintf("%s,%dx%d@%.2f,%dx%d,%.2f,transform,%d", identifier, m.Width,
 		m.Height, m.RefreshRate, m.X, m.Y, m.Scale, m.Transform)
 	if m.Vrr {
 		line += ",vrr,1"

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -75,6 +75,32 @@ func Test__Run_Binary(t *testing.T) {
 		},
 
 		{
+			name:        "headless templating",
+			description: "when hypr returns the headless monitors defined in the configuration, the template should match the golden file",
+			config: createBasicTestConfig(t).WithProfiles(map[string]*config.Profile{
+				"headless": {
+					ConfigType: utils.JustPtr(config.Template),
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name: utils.StringPtr("HEADLESS-2"),
+							},
+						},
+					},
+				},
+			}).FillProfileConfigFile("headless", "testdata/app/templates/basic.toml"),
+			hyprMonitorResponseFiles: []string{"testdata/hypr/server/headless.json"},
+			validateSideEffects: func(t *testing.T, cfg *config.RawConfig) {
+				testutils.AssertFileExists(t, *cfg.General.Destination)
+				compareWithFixture(t, *cfg.General.Destination,
+					"testdata/app/fixtures/headless.conf")
+			},
+			disablePowerEvents: true,
+			disableHotReload:   true,
+			runOnce:            true,
+		},
+
+		{
 			name:        "disable templating extra",
 			description: "when hypr returns more monitors that are defined in the profile the template can use templating to reason about the state",
 			config: createBasicTestConfig(t).WithProfiles(
@@ -333,7 +359,7 @@ func Test__Run_Binary(t *testing.T) {
 							"testdata/app/fixtures/basic_both_bat.conf")
 					},
 				}
-				waitTillHolds(ctx, t, funcs, 200*time.Millisecond)
+				waitTillHolds(ctx, t, funcs, 500*time.Millisecond)
 			},
 			validateSideEffects: func(t *testing.T, cfg *config.RawConfig) {
 				testutils.AssertFileExists(t, *cfg.General.Destination)

--- a/test/testdata/app/fixtures/headless.conf
+++ b/test/testdata/app/fixtures/headless.conf
@@ -1,0 +1,4 @@
+# Template test configuration
+# Generated with power state: AC
+# Generated with lid state: Opened
+monitor=HEADLESS-2,

--- a/test/testdata/hypr/server/headless.json
+++ b/test/testdata/hypr/server/headless.json
@@ -1,0 +1,59 @@
+[
+  {
+    "activeWorkspace": {
+      "id": 20,
+      "name": "20"
+    },
+    "activelyTearing": false,
+    "availableModes": [
+      "1920x1080@0.06Hz"
+    ],
+    "currentFormat": "XRGB8888",
+    "description": "",
+    "directScanoutBlockedBy": [
+      "USER",
+      "CANDIDATE"
+    ],
+    "directScanoutTo": "0",
+    "disabled": false,
+    "dpmsStatus": true,
+    "focused": false,
+    "height": 480,
+    "id": 1,
+    "make": "",
+    "mirrorOf": "none",
+    "model": "",
+    "name": "HEADLESS-2",
+    "physicalHeight": 0,
+    "physicalWidth": 0,
+    "refreshRate": 60.0,
+    "reserved": [
+      0,
+      24,
+      640,
+      480
+    ],
+    "scale": 1.0,
+    "serial": "",
+    "solitary": "0",
+    "solitaryBlockedBy": [
+      "WINDOWED",
+      "CANDIDATE"
+    ],
+    "specialWorkspace": {
+      "id": 0,
+      "name": ""
+    },
+    "tearingBlockedBy": [
+      "NOT_TORN",
+      "USER",
+      "SUPPORT",
+      "CANDIDATE"
+    ],
+    "transform": 0,
+    "vrr": false,
+    "width": 640,
+    "x": 2680,
+    "y": 0
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Allow for empty description in hypr spec, thus:
- freeze and profile maker need to use `.name` when `.desc` is empty

## Why is this change important?

Headless displays cant be configured at the moment, see #47 .

## How to test this PR locally?

`make pre-push`

## Related issues

<!--
Closes #234
-->
Closes #47 