### PR TITLE
fix(upower): propagate information on requiring upower upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ curl -o- https://raw.githubusercontent.com/fiffeek/hyprdynamicmonitors/refs/head
 # AUR (Arch Linux)
 $aurHelper -S hyprdynamicmonitors-bin
 
-# Nix
+# Nix, for flakes/modules see: https://hyprdynamicmonitors.filipmikina.com/docs/advanced/systemd#nix
 nix run github:fiffeek/hyprdynamicmonitors
 ```
 
@@ -141,8 +141,8 @@ See the [`examples/`](https://github.com/fiffeek/hyprdynamicmonitors/tree/main/e
 ## Runtime Requirements
 
 - Hyprland with IPC support
-- UPower (optional, for power state monitoring)
-- D-Bus access (optional, for power events and notifications)
+- UPower (required, unless `--disable-power-events` is passed, for power state monitoring)
+- D-Bus access (required if power events, lid state or notifications are enabled)
 
 ## Alternative Software
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/fiffeek/hyprdynamicmonitors/internal/errs"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/signal"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -58,6 +59,13 @@ func Execute() {
 	}
 	if errors.Is(err, context.Canceled) {
 		logrus.WithError(err).Info("Context cancelled, exiting")
+		return
+	}
+	if errors.Is(err, errs.ErrUPowerMisconfigured) {
+		logrus.Warn(`If lid or power events are enabled, UPower is required to run. Start the service.
+See: https://hyprdynamicmonitors.filipmikina.com/docs/#runtime-requirements.
+Alternatively, disable the power/lid events if you do not expect to use them with --disable-power-events`)
+		logrus.WithError(err).Fatal("Is UPower running?")
 		return
 	}
 	if err != nil {

--- a/docs/docs/advanced/systemd.md
+++ b/docs/docs/advanced/systemd.md
@@ -10,6 +10,10 @@ For production use, it's recommended to run HyprDynamicMonitors as a systemd use
 Ensure you're properly [pushing environment variables to systemd](https://wiki.hypr.land/Nix/Hyprland-on-Home-Manager/#programs-dont-work-in-systemd-services-but-do-on-the-terminal) for correct Hyprland integration.
 :::
 
+:::tip
+If you run with lid or power events enabled, ensure that `UPower` is properly set up and running.
+:::
+
 The [default systemd service configuration](https://github.com/fiffeek/hyprdynamicmonitors/blob/main/infrastructure/systemd/hyprdynamicmonitors.service) assumes you're running Hyprland under systemd:
 ```ini title="infrastructure/systemd/hyprdynamicmonitors.service"
 [Unit]
@@ -62,6 +66,11 @@ If you're running Hyprland outside of systemd, see the [Running Hyprland outside
 ## Nix
 
 HyprDynamicMonitors provides both a NixOS module and a Home Manager module for declarative configuration. Both modules automatically set up the systemd service.
+
+:::warning
+If you're running with [power events enabled (default)](../configuration/power-events#disabling-power-events), or [lid events enabled (`--enable-lid-events` passed)](../configuration/lid-events#enabling-lid-events) then `UPower` is required, e.g.
+`services.upower.enable = true` is needed in your configuration.
+:::
 
 ### NixOS Module
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -61,9 +61,9 @@ Ready to get started? Check out the [Quick Start](./category/quick-start) to set
 ## Runtime Requirements
 
 - Hyprland with IPC support
-- UPower (optional, for power state monitoring)
-- Read-only access to system D-Bus (optional for power state monitoring; should already be your default)
-- Write access to system D-Bus for notifications (optional; should already be your default)
+- [UPower](https://upower.freedesktop.org/) (required if power events or lid events are enabled)
+- Read-only D-Bus access (required if power events, lid state or notifications are enabled)
+- Write access to system D-Bus for notifications (required for notifications; should already be your default)
 
 ## Alternative Software
 

--- a/docs/docs/quickstart/setup-approaches.md
+++ b/docs/docs/quickstart/setup-approaches.md
@@ -8,6 +8,10 @@ Choose your preferred setup approach based on whether you want to run the daemon
 
 ## Choose Your Approach
 
+:::warning
+When running the daemon with power or lid events enabled, make sure that `UPower` is installed and its service is running.
+:::
+
 ### Option A: TUI + Daemon (Recommended for Most Users)
 
 **Best for:** Users who want automatic profile switching and an easy visual setup.

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,6 @@
+// Package errs provides common errors thrown in the app that are expected to be caught upstream
+package errs
+
+import "errors"
+
+var ErrUPowerMisconfigured = errors.New("UPower misconfigured or not running")

--- a/internal/power/lid.go
+++ b/internal/power/lid.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/errs"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
@@ -66,7 +67,8 @@ func NewLidStateDetector(ctx context.Context, cfg *config.Config, conn *dbus.Con
 	ps, err := detector.getCurrentState(ctx)
 	if err != nil {
 		_ = conn.Close()
-		return nil, fmt.Errorf("UPower not available or accessible: %w", err)
+		//nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", errs.ErrUPowerMisconfigured, err)
 	}
 	detector.lidState = ps
 

--- a/internal/power/power.go
+++ b/internal/power/power.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/errs"
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -63,7 +64,8 @@ func NewPowerDetector(ctx context.Context, cfg *config.Config, conn *dbus.Conn, 
 	ps, err := detector.getCurrentState(ctx)
 	if err != nil {
 		_ = conn.Close()
-		return nil, fmt.Errorf("UPower not available or accessible: %w", err)
+		//nolint:errorlint
+		return nil, fmt.Errorf("%w: %v", errs.ErrUPowerMisconfigured, err)
 	}
 	detector.powerState = ps
 


### PR DESCRIPTION
## What does this PR do?

Bubbles up the err for upower conn to main to show users what to do when upower cant connect.

## Why is this change important?

Curernt docs are pretty bad in terms of stating when upower is a required dependency, this clears it up.

## How to test this PR locally?

`make pre-push`
`go build main.go && ./main run --config ./examples/lid-states/config.toml --dry-run --connect-to-session-bus`

## Related issues

Closes #57 
