### PR TITLE
fix(lid): account for lid state in IsEmpty for profile conditions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -593,7 +593,7 @@ func (pc *ProfileCondition) IsEmpty() bool {
 	if pc == nil {
 		return true
 	}
-	return len(pc.RequiredMonitors) == 0 && pc.PowerState == nil
+	return len(pc.RequiredMonitors) == 0 && pc.PowerState == nil && pc.LidState == nil
 }
 
 func (pc *ProfileCondition) Validate() error {


### PR DESCRIPTION
## What does this PR do?
Small fix for IsEmpty on fallback profiles.

## How to test this PR locally?
`make pre-push`

