### PR TITLE
fix: escape # characters in monitor descriptions

### DIFF
--- a/internal/profilemaker/service.go
+++ b/internal/profilemaker/service.go
@@ -300,7 +300,7 @@ func (s *Service) ToHyprLines(monitors hypr.MonitorSpecs) []string {
 
 		identifier := monitor.Name
 		if monitor.Description != "" {
-			identifier = "desc:" + monitor.Description
+			identifier = "desc:" + utils.EscapeHyprDescription(monitor.Description)
 		}
 		line := "monitor=" + identifier
 		fields = append(fields, line)

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/fiffeek/hyprdynamicmonitors/internal/hypr"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
 )
 
 type ColorPreset int
@@ -313,7 +314,7 @@ func (m *MonitorSpec) ToHypr() string {
 	// desc can be empty, use the name as a fallback
 	identifier := m.Name
 	if m.Description != "" {
-		identifier = "desc:" + m.Description
+		identifier = "desc:" + utils.EscapeHyprDescription(m.Description)
 	}
 	if m.Disabled {
 		// nolint:perfsprint

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -13,3 +13,9 @@ func FormatEnumTypes[T HasValue](enums []T) string {
 	}
 	return "[" + strings.Join(mapped, ", ") + "]"
 }
+
+// EscapeHyprDescription escapes # characters in monitor descriptions by doubling them.
+// In Hyprland's configuration syntax, # needs to be escaped as ## when used in desc: fields.
+func EscapeHyprDescription(desc string) string {
+	return strings.ReplaceAll(desc, "#", "##")
+}


### PR DESCRIPTION
## What does this PR do?
Adds a escape to # when in monitor description. This fixes monitor.conf not working, ephemeral apply in tui, and profile matching.

## Why is this change important?

Monitors with # in their name will not function properly.

## How to test this PR locally?

Not sure how to simulate monitors names might be able to do it in a vm.

## Related issues

Closes #61 
