### PR TITLE
test(profilemaker): add tests for # in monitor description

### DIFF
--- a/internal/profilemaker/service_test.go
+++ b/internal/profilemaker/service_test.go
@@ -64,6 +64,18 @@ func TestService_EditExisting(t *testing.T) {
 			Scale:       1.0,
 			Transform:   0,
 		},
+		{
+			ID:          utils.IntPtr(4),
+			Name:        "monD",
+			Description: "Dell #Whatever",
+			Width:       1337,
+			Height:      500,
+			RefreshRate: 60.0,
+			X:           2137,
+			Y:           -5000,
+			Scale:       2.0,
+			Transform:   2,
+		},
 	}
 
 	for _, monitor := range monitors {

--- a/internal/profilemaker/testdata/expected_append_broken_markers.conf
+++ b/internal/profilemaker/testdata/expected_append_broken_markers.conf
@@ -10,4 +10,5 @@ bind = $mainMod, Q, exec, kitty
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_append_no_markers.conf
+++ b/internal/profilemaker/testdata/expected_append_no_markers.conf
@@ -8,4 +8,5 @@ bind = $mainMod, C, killactive
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_empty_config.conf
+++ b/internal/profilemaker/testdata/expected_empty_config.conf
@@ -2,4 +2,5 @@
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_markers_only.conf
+++ b/internal/profilemaker/testdata/expected_markers_only.conf
@@ -2,4 +2,5 @@
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_non_existent.conf
+++ b/internal/profilemaker/testdata/expected_non_existent.conf
@@ -2,4 +2,5 @@
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END

--- a/internal/profilemaker/testdata/expected_replace_markers.conf
+++ b/internal/profilemaker/testdata/expected_replace_markers.conf
@@ -5,6 +5,7 @@ source = ~/.config/hypr/monitors.conf
 monitor=desc:New Monitor A,2560x1440@120.00000,0x0,1.50,transform,0,vrr,0
 monitor=desc:New Monitor B,1920x1080@60.00000,2560x0,1.00,transform,0,vrr,1,bitdepth,10,cm,hdr,sdrbrightness,1.10,sdrsaturation,0.98,mirror,eDP-1
 monitor=monC,1000x1000@60.00000,-1000x-1000,1.00,transform,0,vrr,0
+monitor=desc:Dell ##Whatever,1337x500@60.00000,2137x-5000,2.00,transform,2,vrr,0
 # <<<<< TUI AUTO END
 
 


### PR DESCRIPTION
## What does this PR do?

Adds tests for #62.

## How to test this PR locally?
Regen fixtures with: `go test ./internal/profilemaker -v -regenerate`, then `make test/unit`.

## Related issues
Related to #61 
