### PR TITLE
fix(tui): create config directory if does not exist

### DIFF
--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -33,7 +33,7 @@ var tuiCmd = &cobra.Command{
 			defer f.Close()
 		} else {
 			// disable logging completely for tui unless run in the debug mode
-			logrus.SetLevel(logrus.PanicLevel)
+			logrus.SetLevel(logrus.ErrorLevel)
 		}
 
 		if runningUnderTest {

--- a/internal/app/tui.go
+++ b/internal/app/tui.go
@@ -31,7 +31,8 @@ func NewTUI(ctx context.Context, configPath, mockedHyprMonitors string,
 ) (*TUI, error) {
 	cfg, err := config.NewConfig(configPath)
 	if err != nil {
-		logrus.WithError(err).Error("cant read config, ignoring")
+		logrus.WithError(err).Error("cant create/read config")
+		return nil, fmt.Errorf("cant create/read config: %w", err)
 	}
 
 	var monitors hypr.MonitorSpecs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,10 @@ func Cond(cond, a *string, b string) string {
 }
 
 func CreateDefaultConfig(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("cant create directory: %w", err)
+	}
+
 	objectPath, err := utils.GetPowerLine()
 	if err != nil {
 		logrus.Warning("No power line available, will use a default")

--- a/internal/config/default_config_test.go
+++ b/internal/config/default_config_test.go
@@ -83,6 +83,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateDefaultConfigTemplate(t *testing.T) {
 	t.Run("template renders correctly", func(t *testing.T) {
 		tmpDir := t.TempDir()
+		tmpDir = filepath.Join(tmpDir, "nonexistentdir")
 		configPath := filepath.Join(tmpDir, "config.toml")
 
 		origRunCmd := utils.GetRunCmd()


### PR DESCRIPTION
## What does this PR do?

Create dir structure for a default config.

## Why is this change important?

Fixes #64.

## How to test this PR locally?

`go build main.go && ./main tui --config whatever/config.toml`

## Related issues

Closes #64 .
