### PR TITLE
chore(ci): set up codecov, move coverage reporting to main repo out of forks

### DIFF
--- a/.github/workflows/post-coverage-comment.yaml
+++ b/.github/workflows/post-coverage-comment.yaml
@@ -1,0 +1,54 @@
+---
+name: Post coverage comment (from artifacts)
+
+on:
+    workflow_run:
+        workflows:
+            - Test
+        types:
+            - completed
+
+permissions:
+    contents: read
+    actions: read
+    issues: write
+    pull-requests: write
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+    cancel-in-progress: true
+
+jobs:
+    post-coverage:
+        runs-on: ubuntu-latest
+        if: >
+            ${{
+              github.event.workflow_run.event == 'pull_request' &&
+              github.event.workflow_run.conclusion == 'success'
+            }}
+        steps:
+            - name: Download Coverage Artifact
+              uses: actions/download-artifact@v4
+              with:
+                  name: coverage-xml
+                  run-id: ${{ github.event.workflow_run.id }}
+                  github-token: ${{ github.token }}
+
+            - name: Code Coverage Report
+              uses: irongut/CodeCoverageSummary@v1.3.0
+              with:
+                  filename: coverage.xml
+                  badge: true
+                  fail_below_min: false
+                  format: markdown
+                  hide_branch_rate: false
+                  hide_complexity: true
+                  indicators: true
+                  output: both
+
+            - name: Add Coverage PR Comment
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  recreate: true
+                  path: code-coverage-results.md
+                  number: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,6 @@ on:
             - main
 
 permissions:
-    pull-requests: write
     contents: read
 
 jobs:
@@ -83,24 +82,18 @@ jobs:
             - name: Create coverage artifact
               run: make coverage
 
-            - name: Generate code coverage report
-              uses: irongut/CodeCoverageSummary@v1.3.0
+            - name: Upload coverage markdown as artifact
+              uses: actions/upload-artifact@v4
               with:
-                  filename: coverage.xml
-                  badge: false
-                  fail_below_min: false
-                  format: markdown
-                  hide_branch_rate: false
-                  hide_complexity: true
-                  indicators: true
-                  output: both
+                  name: coverage-xml
+                  path: coverage.xml
+                  retention-days: 7
 
-            - name: Add Coverage PR Comment
-              uses: marocchino/sticky-pull-request-comment@v2
-              if: github.event_name == 'pull_request'
+            - uses: codecov/codecov-action@v5
+              if: github.ref == 'refs/heads/main'
               with:
-                  recreate: true
-                  path: code-coverage-results.md
+                  files: ./coverage.xml
+                  token: ${{ secrets.CODECOV_TOKEN }}
 
     nix:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Sets up codecov reporting on main, moves coverage reporting comment to the main repo so that forks do not have to have access.

## Why is this change important?

Fixes #68 

## How to test this PR locally?

Well... test in prod I guess?

## Related issues

Closes #68 
