### PR TITLE
feat: detect running on desktop, disable power/lid events for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See the [`examples/`](https://github.com/fiffeek/hyprdynamicmonitors/tree/main/e
 ## Runtime Requirements
 
 - Hyprland with IPC support
-- UPower (required, unless `--disable-power-events` is passed, for power state monitoring)
+- UPower (required on laptops, unless `--disable-power-events` is passed, for power state monitoring)
 - D-Bus access (required if power events, lid state or notifications are enabled)
 
 ## Alternative Software

--- a/docs/docs/configuration/power-events.md
+++ b/docs/docs/configuration/power-events.md
@@ -21,6 +21,15 @@ When disabled:
 - No power events will be delivered
 - No D-Bus connection will be made
 
+## Enabling Power Events
+
+Power events are enabled by default on laptops. They are disabled on desktops (the current chassis type is pulled from `/sys/class/dmi/id/chassis_type`).
+If you want to enable them anyway, run, e.g.:
+
+```bash
+hyprdynamicmonitors run --disable-power-events=false
+```
+
 ## Default Configuration
 
 By default, the service listens for D-Bus signals:

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -214,6 +214,16 @@ Yes! HyprDynamicMonitors can work alongside `nwg-displays`:
 
 This combines the visual configuration of `nwg-displays` with the automatic profile management of `hyprdynamicmonitors`.
 
+## Is UPower Running? UPower misconfigured or not running: failed to get property from UPower: Object does not exist at path “/org/freedesktop/UPower/devices/line_power_ACAD”
+
+If you got this error, you either want to:
+1. If you do not want to use power events (e.g., on a desktop), pass the `--disable-power-events` CLI argument
+2. Tweak your [Power Events configuration](./configuration/power-events.md) to use the proper device path (`upower -e` to find your `line_power` device; additionally, it would be helpful if you added it [here](https://github.com/fiffeek/hyprdynamicmonitors/blob/main/internal/utils/power.go#L14) so that others do not encounter this issue going forward)
+
+If you are running on a desktop with a version of `hyprdynamicmonitors` that includes [this patch](https://github.com/fiffeek/hyprdynamicmonitors/pull/80) (`v1.3.5+`),
+this error should not occur unless `--disable-power-events=false` is explicitly passed, since power events are disabled
+for desktops by default. Please [open an issue](https://github.com/fiffeek/hyprdynamicmonitors/issues) and include the output of `cat /sys/class/dmi/id/chassis_type`.
+
 ## See Also
 
 - [Examples](https://github.com/fiffeek/hyprdynamicmonitors/tree/main/examples) - Complete configuration examples

--- a/docs/docs/quickstart/setup-approaches.md
+++ b/docs/docs/quickstart/setup-approaches.md
@@ -9,7 +9,14 @@ Choose your preferred setup approach based on whether you want to run the daemon
 ## Choose Your Approach
 
 :::warning
-When running the daemon with power or lid events enabled, make sure that `UPower` is installed and its service is running.
+The app will try to detect your chassis type from `/sys/class/dmi/id/chassis_type` on startup.
+If a desktop is detected, it will disable power events unless explicitly enabled (by passing `--disable-power-events=false`).
+On laptops, power events are enabled by default (pass `--disable-power-events` to disable them).
+:::
+
+:::warning
+When running the daemon with power (default) or lid events enabled, make sure that `UPower` is installed and its service is running.
+If you're running on a desktop you likely want both disabled (pass `--disable-power-events`).
 :::
 
 ### Option A: TUI + Daemon (Recommended for Most Users)

--- a/docs/docs/usage/commands.md
+++ b/docs/docs/usage/commands.md
@@ -55,7 +55,7 @@ Usage:
 Flags:
       --connect-to-session-bus    Connect to session bus instead of system bus for power events: https://wiki.archlinux.org/title/D-Bus. You can switch as long as you expose power line events in your user session bus.
       --disable-auto-hot-reload   Disable automatic hot reload (no file watchers)
-      --disable-power-events      Disable power events (dbus)
+      --disable-power-events      Disable power events (dbus). Defaults to true if running on desktop, to false otherwise
       --dry-run                   Show what would be done without making changes
       --enable-lid-events         Enable listening to dbus lid events
   -h, --help                      help for run
@@ -221,7 +221,7 @@ Usage:
 
 Flags:
       --connect-to-session-bus          Connect to session bus instead of system bus for power events: https://wiki.archlinux.org/title/D-Bus. You can switch as long as you expose power line events in your user session bus.
-      --disable-power-events            Disable power events (dbus)
+      --disable-power-events            Disable power events (dbus). Defaults to true if running on desktop, to false otherwise
       --enable-lid-events               Enable listening to dbus lid events
   -h, --help                            help for tui
       --hypr-monitors-override string   When used it fill parse the given file as hyprland monitors spec, used for testing.

--- a/internal/utils/dmi.go
+++ b/internal/utils/dmi.go
@@ -1,0 +1,73 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	dmiPathEnvVarOverride = "HYPRDYNAMICMONITORS_DMI_PATH_OVERRIDE"
+	dmiPath               = "/sys/class/dmi/id/chassis_type"
+)
+
+// laptopLikeCodes are the SMBIOS/ DMI chassis_type numeric codes that indicate "laptop-like".
+var laptopLikeCodes = map[int]struct{}{
+	8:  {}, // Portable
+	9:  {}, // Laptop
+	10: {}, // Notebook
+	14: {}, // Sub Notebook
+	31: {}, // Convertible
+	32: {}, // Detachable
+}
+
+func readChassisType() (int, error) {
+	path, ok := os.LookupEnv(dmiPathEnvVarOverride)
+	if !ok {
+		path = dmiPath
+	}
+
+	//nolint:gosec
+	dmiContents, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("can't read chassis type: %w", err)
+	}
+	s := strings.TrimSpace(string(dmiContents))
+
+	// Some kernels expose numeric; some distros might echo names (rare). Try parsing int first.
+	if num, err := strconv.Atoi(s); err == nil {
+		return num, nil
+	}
+
+	// fallback: map some textual values to numbers (if present)
+	// common textual outputs: "Notebook", "Laptop", "Desktop"
+	switch strings.ToLower(s) {
+	case "portable":
+		return 8, nil
+	case "laptop", "notebook":
+		return 10, nil
+	case "sub-notebook", "sub notebook":
+		return 14, nil
+	case "desktop":
+		return 3, nil
+	case "server":
+		return 17, nil
+	default:
+		return 0, nil
+	}
+}
+
+func IsLaptop() bool {
+	dmiCode, err := readChassisType()
+	if err != nil {
+		logrus.WithError(err).Warn("can't read DMI code")
+		// assume laptop for backwards compatibility
+		return true
+	}
+
+	_, ok := laptopLikeCodes[dmiCode]
+	return ok
+}

--- a/internal/utils/dmi_test.go
+++ b/internal/utils/dmi_test.go
@@ -1,0 +1,205 @@
+package utils_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLaptop(t *testing.T) {
+	tests := []struct {
+		name           string
+		dmiContent     string
+		expectedLaptop bool
+		description    string
+	}{
+		{
+			name:           "laptop code 8 - Portable",
+			dmiContent:     "8",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 8 (Portable)",
+		},
+		{
+			name:           "laptop code 9 - Laptop",
+			dmiContent:     "9",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 9 (Laptop)",
+		},
+		{
+			name:           "laptop code 10 - Notebook",
+			dmiContent:     "10",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 10 (Notebook)",
+		},
+		{
+			name:           "laptop code 14 - Sub Notebook",
+			dmiContent:     "14",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 14 (Sub Notebook)",
+		},
+		{
+			name:           "laptop code 31 - Convertible",
+			dmiContent:     "31",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 31 (Convertible)",
+		},
+		{
+			name:           "laptop code 32 - Detachable",
+			dmiContent:     "32",
+			expectedLaptop: true,
+			description:    "Numeric chassis type 32 (Detachable)",
+		},
+		{
+			name:           "desktop code 3",
+			dmiContent:     "3",
+			expectedLaptop: false,
+			description:    "Numeric chassis type 3 (Desktop)",
+		},
+		{
+			name:           "server code 17",
+			dmiContent:     "17",
+			expectedLaptop: false,
+			description:    "Numeric chassis type 17 (Server)",
+		},
+		{
+			name:           "text portable",
+			dmiContent:     "Portable",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'Portable'",
+		},
+		{
+			name:           "text laptop lowercase",
+			dmiContent:     "laptop",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'laptop' (lowercase)",
+		},
+		{
+			name:           "text laptop mixed case",
+			dmiContent:     "Laptop",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'Laptop' (mixed case)",
+		},
+		{
+			name:           "text notebook lowercase",
+			dmiContent:     "notebook",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'notebook' (lowercase)",
+		},
+		{
+			name:           "text notebook mixed case",
+			dmiContent:     "Notebook",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'Notebook' (mixed case)",
+		},
+		{
+			name:           "text sub-notebook with hyphen",
+			dmiContent:     "sub-notebook",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'sub-notebook' (with hyphen)",
+		},
+		{
+			name:           "text sub notebook without hyphen",
+			dmiContent:     "sub notebook",
+			expectedLaptop: true,
+			description:    "Textual chassis type 'sub notebook' (without hyphen)",
+		},
+		{
+			name:           "text desktop",
+			dmiContent:     "Desktop",
+			expectedLaptop: false,
+			description:    "Textual chassis type 'Desktop'",
+		},
+		{
+			name:           "text server",
+			dmiContent:     "Server",
+			expectedLaptop: false,
+			description:    "Textual chassis type 'Server'",
+		},
+		{
+			name:           "code with whitespace",
+			dmiContent:     "  10  \n",
+			expectedLaptop: true,
+			description:    "Numeric code with leading/trailing whitespace",
+		},
+		{
+			name:           "text with whitespace",
+			dmiContent:     "  laptop  \n",
+			expectedLaptop: true,
+			description:    "Textual value with leading/trailing whitespace",
+		},
+		{
+			name:           "unknown numeric code",
+			dmiContent:     "99",
+			expectedLaptop: false,
+			description:    "Unknown numeric chassis type",
+		},
+		{
+			name:           "unknown text value",
+			dmiContent:     "Unknown",
+			expectedLaptop: false,
+			description:    "Unknown textual chassis type",
+		},
+		{
+			name:           "empty file",
+			dmiContent:     "",
+			expectedLaptop: false,
+			description:    "Empty DMI file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			dmiFile := filepath.Join(tmpDir, "chassis_type")
+
+			err := os.WriteFile(dmiFile, []byte(tt.dmiContent), 0o600)
+			require.NoError(t, err, "Failed to write test DMI file")
+
+			t.Setenv("HYPRDYNAMICMONITORS_DMI_PATH_OVERRIDE", dmiFile)
+
+			result := utils.IsLaptop()
+			assert.Equal(t, tt.expectedLaptop, result, tt.description)
+		})
+	}
+}
+
+func TestIsLaptop_FileNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistentFile := filepath.Join(tmpDir, "does_not_exist")
+
+	t.Setenv("HYPRDYNAMICMONITORS_DMI_PATH_OVERRIDE", nonExistentFile)
+
+	result := utils.IsLaptop()
+	assert.True(t, result, "IsLaptop should return true when DMI file doesn't exist (backwards compatibility)")
+}
+
+func TestIsLaptop_NoPermission(t *testing.T) {
+	tmpDir := t.TempDir()
+	dmiFile := filepath.Join(tmpDir, "chassis_type")
+
+	err := os.WriteFile(dmiFile, []byte("10"), 0o600)
+	require.NoError(t, err, "Failed to write test DMI file")
+
+	err = os.Chmod(dmiFile, 0o000)
+	require.NoError(t, err, "Failed to change file permissions")
+
+	t.Cleanup(func() {
+		_ = os.Chmod(dmiFile, 0o600)
+	})
+
+	t.Setenv("HYPRDYNAMICMONITORS_DMI_PATH_OVERRIDE", dmiFile)
+
+	result := utils.IsLaptop()
+	assert.True(t, result, "IsLaptop should return true when DMI file can't be read (backwards compatibility)")
+}
+
+func TestIsLaptop_DefaultPath(t *testing.T) {
+	os.Unsetenv("HYPRDYNAMICMONITORS_DMI_PATH_OVERRIDE")
+	// Just verify that it doesn't panic
+	result := utils.IsLaptop()
+	t.Logf("IsLaptop on this system returned: %v", result)
+}

--- a/internal/utils/logid.go
+++ b/internal/utils/logid.go
@@ -15,6 +15,7 @@ const (
 	DryRunLogID
 	PreExecLogID
 	PostExecLogID
+	DisablingPowerEventsLogID
 )
 
 type LogrusCustomFields struct {


### PR DESCRIPTION
## What does this PR do?

Disables power events on desktops by default (still enabled on laptops).

## Why is this change important?

User requested in #79 

## How to test this PR locally?

`make pre-push`

## Related issues

Closes #79 
