### PR TITLE
docs: fix default config path

### DIFF
--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Overview
 
-HyprDynamicMonitors automatically creates a default configuration file on first run if none exists at the specified path (defaults to `~/.config/hypr/hyprdynamicmonitors.toml`).
+HyprDynamicMonitors automatically creates a default configuration file on first run if none exists at the specified path (defaults to `~/.config/hyprdynamicmonitors/config.toml`).
 
 ## Default Configuration
 


### PR DESCRIPTION
## What does this PR do?

Fixes default config path in the documentation.

## Related issues

Closes #85 
