### PR TITLE
fix: do not catch C&E keybinds when the profile name is being edited

### DIFF
--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -448,9 +448,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyMsg:
 			switch {
 			case key.Matches(msg, m.keys.EditHDMConfig):
-				cmds = append(cmds, openEditor(m.config.Get().ConfigPath))
+				if !m.rootState.State.ProfileNameRequested {
+					cmds = append(cmds, openEditor(m.config.Get().ConfigPath))
+				}
 			case key.Matches(msg, m.keys.EditHyprGeneratedConfig):
-				cmds = append(cmds, openEditor(*m.config.Get().General.Destination))
+				if !m.rootState.State.ProfileNameRequested {
+					cmds = append(cmds, openEditor(*m.config.Get().General.Destination))
+				}
 			}
 		}
 	}

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -727,6 +727,31 @@ func TestModel_Update_UserFlows(t *testing.T) {
 		},
 
 		{
+			name:         "new_profile_name_problem",
+			monitorsData: defaultMonitorData,
+			runFor:       utils.JustPtr(500 * time.Millisecond),
+			cfg:          testutils.NewTestConfig(t).Get(),
+			steps: []step{
+				{
+					msg:                   tea.KeyMsg{Type: tea.KeyTab},
+					expectOutputToContain: "No Matching Profile",
+				},
+				{
+					msg:                   tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}},
+					expectOutputToContain: "Type the profile name",
+				},
+				{
+					msg:                   tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'C'}},
+					expectOutputToContain: "C",
+				},
+				{
+					msg:                   tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'E'}},
+					expectOutputToContain: "CE",
+				},
+			},
+		},
+
+		{
 			name:         "new_profile_name_open",
 			monitorsData: defaultMonitorData,
 			runFor:       utils.JustPtr(500 * time.Millisecond),

--- a/internal/tui/testdata/TestModel_Update_UserFlows/new_profile_name_problem.golden
+++ b/internal/tui/testdata/TestModel_Update_UserFlows/new_profile_name_problem.golden
@@ -1,0 +1,45 @@
+ HyprDynamicMonitors [v. test-version]  Monitors  Profile                                                                                                       
+╭───────────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
+│HyprDynamicMonitors Profile                        ││No profile config                                                                                       │ 
+│                                                   ││                                                                                                        │ 
+│No Matching Profile                                ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│No configuration profile matches the current       ││                                                                                                        │ 
+│monitor setup.                                     ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│Press 'n' to create a new profile                  ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   │╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
+│                                                   │╭────────────────────────────────────────────────────────────────────────────────────────────────────────╮ 
+│                                                   ││Generated hypr config preview                                                                           │ 
+│                                                   ││target.conf                                                                                             │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││Are you running the daemon?                                                                             │ 
+│  n new profile • a apply monitors to existing     ││See: https://hyprdynamicmonitors.filipmikina.com/docs/quickstart/setup-approaches                       │ 
+│  profile • e edit manually • R render profile to  ││                                                                                                        │ 
+│  config.general.destination                       ││Alternatively, run the generation once: `hyprdynamicmonitors run --run-once`                            │ 
+╰───────────────────────────────────────────────────╯│                                                                                                        │ 
+╭───────────────────────────────────────────────────╮│                                                                                                        │ 
+│Type the profile name                              ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│> CE                                               ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│                                                   ││                                                                                                        │ 
+│enter create profile • esc return/back             ││                                                                                                        │ 
+╰───────────────────────────────────────────────────╯╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯ 
+  tab switch view • C edit HyprDynamicMonitors config • E edit hypr generated config (ephemeral)                                                                
+                                                                                                                                                                


### PR DESCRIPTION
## What does this PR do?

`C` and `E` would be caught by the root keymap when the profile name was requested so users could not type these chars.

## How to test this PR locally?

`make test/unit`

## Related issues

Closes #95 
