### PR TITLE
feat: allow for regex matching for "description" and "name" in `required_monitors"

### DIFF
--- a/docs/docs/configuration/monitor-matching.md
+++ b/docs/docs/configuration/monitor-matching.md
@@ -18,25 +18,46 @@ You can match monitors by:
 
 The monitor's connector name (e.g., `eDP-1`, `DP-1`, `HDMI-A-1`)
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [[profiles.laptop_only.conditions.required_monitors]]
 name = "eDP-1"  # Match by connector name
 ```
+
+:::info
+You can use regex matching for the monitor name:
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
+[[profiles.laptop_only.conditions.required_monitors]]
+name = "DP-.*"
+match_name_using_regex = true
+```
+It is disabled by default.
+:::
 
 ### Description
 
 The monitor's model/manufacturer string as reported by Hyprland
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [[profiles.external_4k.conditions.required_monitors]]
 description = "Dell U2720Q"  # Match by monitor model
 ```
 
-### Tags (Optional)
+:::info
+You can use regex matching for the monitor description:
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
+[[profiles.laptop_only.conditions.required_monitors]]
+description = "Dell.*"
+match_description_using_regex = true
+```
+
+It is disabled by default.
+:::
+
+## Tags (Optional)
 
 Custom labels you assign to monitors for easier reference in templates
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [[profiles.dual_setup.conditions.required_monitors]]
 name = "eDP-1"
 monitor_tag = "laptop"  # Assign a tag for template use
@@ -75,7 +96,7 @@ When multiple profiles could match the current setup, HyprDynamicMonitors uses a
 
 ### Example: Profile Priority
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 # This profile will be selected for laptop-only setup
 [profiles.laptop_basic]
 config_file = "hyprconfigs/laptop-basic.conf"
@@ -95,7 +116,7 @@ When only `eDP-1` is connected, both profiles match, but `laptop_optimized` is s
 
 You can customize the scoring weights to prioritize different matching criteria:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [scoring]
 name_match = 10       # Points for exact monitor name match
 description_match = 5 # Points for exact monitor description match
@@ -106,6 +127,46 @@ lid_state_match = 2   # Bonus points for matching lid state
 Higher values give more weight to specific criteria. For example, if you want power state matching to have more influence, increase the `power_state_match` value.
 
 See [Configuration Overview](./overview#scoring) for more details.
+
+## Regex matching for monitor name or description
+
+You can use regexes to match similar monitor setups, e.g. you are in a library that has very similar monitors but with different `description` each -- you can write
+a catch all profile to match these:
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
+[[profiles.library.conditions.required_monitors]]
+description = "Dell.*"
+match_description_using_regex = true
+```
+
+It is important to note that one `required_monitors` will match exactly one connected output, e.g. imagine that you're connected to two `Dell1` and `Dell2` monitors:
+```bash
+❯ hyprctl monitors | grep desc
+        description: Dell1
+        description: Dell2
+```
+
+Writing a profile like this:
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
+[[profiles.library_one.conditions.required_monitors]]
+description = "Dell.*"
+match_description_using_regex = true
+```
+This profile will match because all required monitors (just one) are present. However, it only matches one of the two Dell monitors.
+
+To match both Dell monitors, define two required_monitor entries:
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
+[[profiles.library_two.conditions.required_monitors]]
+description = "Dell.*"
+match_description_using_regex = true
+
+[[profiles.library_two.conditions.required_monitors]]
+description = "Dell.*"
+match_description_using_regex = true
+```
+
+Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#scoring-system)) it would be picked up as the current setup.
+
+Moreover, if you do assign tags, they are deterministic -- so for exactly the same setup (`monitor id` matters), same template would be produced.
 
 ## Best Practices
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -21,7 +21,7 @@ The configuration file is written in TOML and consists of several main sections:
 
 ### General Settings
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [general]
 destination = "$HOME/.config/hypr/monitors.conf"
 debounce_time_ms = 1500
@@ -38,7 +38,7 @@ See [Callbacks](./callbacks) for details on exec commands.
 
 ### Power Events
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [power_events]
 [power_events.dbus_query_object]
 path = "/org/freedesktop/UPower/devices/line_power_ACAD"
@@ -51,7 +51,7 @@ Power events monitor your system's power state (AC/Battery) via D-Bus. See [Powe
 
 ### Lid Events
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [lid_events]
 # custom config goes here, the defaults should work in most cases
 ```
@@ -60,7 +60,7 @@ Lid events monitor your system's lid state (Opened/Closed) via D-Bus. See [Lid E
 
 ### Profiles
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.laptop_only]
 config_file = "hyprconfigs/laptop.conf"
 config_file_type = "static"
@@ -78,7 +78,7 @@ See [Profiles](./profiles) for details.
 
 ### Notifications
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [notifications]
 disabled = false
 timeout_ms = 10000
@@ -88,7 +88,7 @@ Configure desktop notifications for configuration changes. See [Notifications](.
 
 ### Hot Reload
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [hot_reload_section]
 debounce_time_ms = 1000
 ```
@@ -97,7 +97,7 @@ Hot reload watches configuration files for changes and automatically reloads the
 
 ### Scoring
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [scoring]
 name_match = 10
 description_match = 5
@@ -115,7 +115,7 @@ See [Monitor Matching](./monitor-matching) for details on how profiles are selec
 
 ### Static Template Values
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [static_template_values]
 default_vrr = "1"
 default_res = "2880x1920"
@@ -125,7 +125,7 @@ Define global values that can be used in all templates. These can be overridden 
 
 ### Fallback Profile
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [fallback_profile]
 config_file = "hyprconfigs/fallback.conf"
 config_file_type = "static"

--- a/docs/docs/configuration/profiles.md
+++ b/docs/docs/configuration/profiles.md
@@ -8,18 +8,22 @@ Profiles define different monitor configurations for different setups. Each prof
 
 ## Profile Structure
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.PROFILE_NAME]
-config_file = "path/to/config/file"
+config_file = "path/to/config/file" # can be absolute or relative to the config.toml file
 config_file_type = "static"  # or "template"
 
 [profiles.PROFILE_NAME.conditions]
-power_state = "AC"      # optional: "AC" or "BAT"
+power_state = "AC"      # optional: "AC" or "BAT" (requires --disable-power-events=false)
 lid_state = "Opened"    # optional: "Opened" or "Closed" (requires --enable-lid-events)
 
+# at least one required_monitor needs to be defined in a given profile
 [[profiles.PROFILE_NAME.conditions.required_monitors]]
-name = "eDP-1"
+name = "eDP-1"  # optional but one of description/name is required
+description = "LG" # optional but one of description/name is required
 monitor_tag = "laptop"  # optional
+match_description_using_regex = true # optional, defaults to false
+match_name_using_regex = true # optional, defaults to false
 ```
 
 ## Configuration File Types
@@ -28,7 +32,7 @@ monitor_tag = "laptop"  # optional
 
 Static configurations are plain Hyprland config files. The service creates a symlink to them.
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.laptop_only]
 config_file = "hyprconfigs/laptop.conf"
 config_file_type = "static"
@@ -43,7 +47,7 @@ monitor=eDP-1,2880x1920@120,0x0,2.0,vrr,1
 
 Templates use Go template syntax for dynamic configuration generation.
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.dual_monitor]
 config_file = "hyprconfigs/dual.go.tmpl"
 config_file_type = "template"
@@ -54,11 +58,12 @@ monitor_tag = "laptop"
 
 [[profiles.dual_monitor.conditions.required_monitors]]
 description = "LG.*ULTRAWIDE"
+match_description_using_regex = true
 monitor_tag = "external"
 ```
 
 **hyprconfigs/dual.go.tmpl:**
-```go
+```go title="~/.config/hyprdynamicmonitors/hyprconfigs/dual.go.tmpl"
 {{- $laptop := index .MonitorsByTag "laptop" -}}
 {{- $external := index .MonitorsByTag "external" -}}
 monitor={{$laptop.Name}},{{if isOnAC}}2880x1920@120{{else}}1920x1080@60{{end}},0x0,2.0
@@ -73,7 +78,7 @@ See [Templates](../advanced/templates) for details on template syntax and variab
 
 Each profile can require specific monitors to be connected. A profile matches when all its required monitors are present.
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 # Single monitor
 [[profiles.laptop_only.conditions.required_monitors]]
 name = "eDP-1"
@@ -93,7 +98,7 @@ description = "LG 27UK850"
 
 You can restrict a profile to only match on specific power states:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.performance_mode.conditions]
 power_state = "AC"  # Only match when plugged into AC power
 
@@ -118,7 +123,7 @@ See [Power States Example](https://github.com/fiffeek/hyprdynamicmonitors/tree/m
 
 You can restrict a profile to only match on specific lid states (requires `--enable-lid-events` flag):
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.lid_closed.conditions]
 lid_state = "Closed"  # Only match when lid is closed
 
@@ -143,7 +148,7 @@ See [Lid States Example](https://github.com/fiffeek/hyprdynamicmonitors/tree/mai
 
 You can combine monitor, power state, and lid state conditions:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.docked_ac.conditions]
 power_state = "AC"
 lid_state = "Closed"
@@ -168,7 +173,7 @@ You can define custom values that are available in templates. These can be defin
 
 Available in all templates:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [static_template_values]
 default_vrr = "1"
 default_res = "2880x1920"
@@ -180,7 +185,7 @@ refresh_rate_low = "60.00000"
 
 Override global values or add profile-specific values:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [profiles.laptop_only.static_template_values]
 default_vrr = "0"        # Override global value
 battery_scaling = "1.5"  # Profile-specific value
@@ -196,7 +201,7 @@ monitor=eDP-1,{{.default_res}}@{{if isOnAC}}{{.refresh_rate_high}}{{else}}{{.ref
 
 When no regular profile matches, you can define a fallback profile:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [fallback_profile]
 config_file = "hyprconfigs/fallback.conf"
 config_file_type = "static"
@@ -217,7 +222,7 @@ monitor=,preferred,auto,1
 
 You can define commands to execute before and after profile application:
 
-```toml
+```toml title="~/.config/hyprdynamicmonitors/config.toml"
 [general]
 # Global exec commands - run for all profile changes
 pre_apply_exec = "notify-send 'Switching profile...'"

--- a/examples/full/config.toml
+++ b/examples/full/config.toml
@@ -266,3 +266,18 @@ monitor_tag = "laptop"
 # Generic match for various projectors/presentation displays
 description = "Projector" # Or match specific projector model
 monitor_tag = "projector"
+
+# Profile: Match by regex
+[profiles.regex]
+config_file = "hyprconfigs/regex.conf.tmpl"
+config_file_type = "template"
+
+[[profiles.regex.conditions.required_monitors]]
+name = "eDP.*"
+monitor_tag = "laptop"
+match_name_using_regex = true
+
+[[profiles.regex.conditions.required_monitors]]
+description = "LG.*"
+monitor_tag = "external"
+match_description_using_regex = true

--- a/examples/full/hyprconfigs/regex.conf.tmpl
+++ b/examples/full/hyprconfigs/regex.conf.tmpl
@@ -1,0 +1,11 @@
+{{- $laptop := index .MonitorsByTag "laptop" -}}
+{{- $external := index .MonitorsByTag "external" -}}
+
+# Yet another configuration matched by regexes
+{{- if $laptop }}
+monitor={{$laptop.Name}},2880x1920@60.00000,0x0,2.0
+{{- end }}
+
+{{- if $external }}
+monitor={{$external.Name}},2880x1920@60.00000,0x0,2.0
+{{- end }}

--- a/internal/config/testdata/fixtures/minimal.toml
+++ b/internal/config/testdata/fixtures/minimal.toml
@@ -6,6 +6,8 @@ config_file_type = "static"
 
 [[profiles.minimal.conditions.required_monitors]]
 name = "eDP-1"
+match_description_using_regex = false
+match_name_using_regex = false
 
 [general]
 destination = "/.config/hypr/monitors.conf"

--- a/internal/matchers/main_test.go
+++ b/internal/matchers/main_test.go
@@ -1,0 +1,19 @@
+package matchers_test
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+var debug = flag.Bool("debug", false, "run with logrus debug")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *debug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/matchers/matcher_test.go
+++ b/internal/matchers/matcher_test.go
@@ -1,13 +1,15 @@
-package matchers
+package matchers_test
 
 import (
 	"testing"
 
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/hypr"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/matchers"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/power"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/testutils"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMatcher_Match(t *testing.T) {
@@ -17,9 +19,75 @@ func TestMatcher_Match(t *testing.T) {
 		connectedMonitors []*hypr.MonitorSpec
 		powerState        power.PowerState
 		lidState          power.LidState
-		expectedProfile   string // profile name or empty string for no match
-		description       string
+		expectedProfile   string
+		// profile name or empty string for no match
+		expectedMonitorToRule map[int]*config.RequiredMonitor
+		// optional: validate monitor to rule mapping
+		description string
 	}{
+		{
+			name: "regex description",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"regex": {
+					Name: "regex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Dell Inc. DELL P2422H 8LFQ514"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "regex",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(
+					true), MatchNameUsingRegex: utils.JustPtr(false)},
+			},
+			description: "Description matches by regex",
+		},
+		{
+			name: "no regex description",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"noregex": {
+					Name: "noregex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Dell.*")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Dell Inc. DELL P2422H 8LFQ514"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Description does not match if regex flag is not provided",
+		},
+		{
+			name: "do not use same monitor twice",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"dual_monitors": {
+					Name: "dual_monitors",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			powerState:            power.ACPowerState,
+			expectedProfile:       "",
+			expectedMonitorToRule: nil, // No match, so no mapping expected
+			description:           "Required two of the 'same' monitors but only one is present",
+		},
 		{
 			name: "exact_name_match_wins",
 			config: createTestConfig(t, map[string]*config.Profile{
@@ -47,7 +115,17 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.ACPowerState,
 			expectedProfile: "dual_monitors",
-			description:     "Higher scoring profile (2 name matches) should win over lower scoring (1 name match)",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+				1: {
+					Name: utils.StringPtr("DP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Higher scoring profile (2 name matches) should win over lower scoring (1 name match)",
 		},
 		{
 			name: "description_match_works",
@@ -66,7 +144,13 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.ACPowerState,
 			expectedProfile: "external_only",
-			description:     "Profile should match based on description",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Description:         utils.StringPtr("External Monitor"),
+					MatchNameUsingRegex: utils.JustPtr(false), MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile should match based on description",
 		},
 		{
 			name: "lid_state_scoring",
@@ -103,7 +187,13 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			lidState:        power.ClosedLidState,
 			expectedProfile: "lid_closed",
-			description:     "Profile with matching lid state should win (name match + power state match vs just name match)",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile with matching lid state should win (name match + power state match vs just name match)",
 		},
 		{
 			name: "power_state_scoring",
@@ -132,7 +222,13 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.BatteryPowerState,
 			expectedProfile: "battery_profile",
-			description:     "Profile with matching power state should win (name match + power state match vs just name match)",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile with matching power state should win (name match + power state match vs just name match)",
 		},
 		{
 			name: "partial_match_discarded",
@@ -200,7 +296,17 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.ACPowerState,
 			expectedProfile: "mixed_high_score",
-			description:     "Profile with mixed name+description scoring (15 points) should win over name-only (10 points)",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+				1: {
+					Description:         utils.StringPtr("External Monitor"),
+					MatchNameUsingRegex: utils.JustPtr(false), MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile with mixed name+description scoring (15 points) should win over name-only (10 points)",
 		},
 		{
 			name: "power_state_mismatch_discards_profile",
@@ -244,9 +350,10 @@ func TestMatcher_Match(t *testing.T) {
 			connectedMonitors: []*hypr.MonitorSpec{
 				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
 			},
-			powerState:      power.ACPowerState,
-			expectedProfile: "fallback",
-			description:     "Fallback profile should be used when no regular profile matches",
+			powerState:            power.ACPowerState,
+			expectedProfile:       "fallback",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{}, // Fallback profile has no monitor requirements
+			description:           "Fallback profile should be used when no regular profile matches",
 		},
 		{
 			name: "regular_profile_preferred_over_fallback",
@@ -272,7 +379,13 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.ACPowerState,
 			expectedProfile: "laptop_only",
-			description:     "Regular matching profile should be preferred over fallback profile",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Regular matching profile should be preferred over fallback profile",
 		},
 		{
 			name: "no_match_no_fallback_returns_false",
@@ -341,13 +454,798 @@ func TestMatcher_Match(t *testing.T) {
 			},
 			powerState:      power.ACPowerState,
 			expectedProfile: "second_profile",
-			description:     "When two profiles have equal scores, the last one in TOML order should win",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "When two profiles have equal scores, the last one in TOML order should win",
+		},
+		{
+			name: "both_name_and_description_match_same_monitor",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"full_match": {
+					Name: "full_match",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("Built-in Display"),
+							},
+						},
+					},
+				},
+				"name_only": {
+					Name: "name_only",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "full_match",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), Description: utils.StringPtr("Built-in Display"),
+					MatchNameUsingRegex: utils.JustPtr(false), MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile matching both name and description on same monitor should score higher (15 points) than name-only (10 points)",
+		},
+		{
+			name: "best_monitor_selected_for_rule",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"best_match": {
+					Name: "best_match",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							// This rule could match either monitor, but should pick the one with both name and desc
+							{
+								Name:        utils.StringPtr("DP-1"),
+								Description: utils.StringPtr("Dell Monitor"),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Generic Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "Dell Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "best_match",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				1: {
+					Name:                       utils.StringPtr("DP-1"),
+					Description:                utils.StringPtr("Dell Monitor"),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+					MatchNameUsingRegex:        utils.JustPtr(false),
+				},
+			},
+			description: "When multiple monitors could match, should select the one with highest score (name+desc match over just name match)",
+		},
+		{
+			name: "lid_state_mismatch_discards_profile",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"lid_closed_only": {
+					Name: "lid_closed_only",
+					Conditions: &config.ProfileCondition{
+						LidState: utils.JustPtr(config.ClosedLidStateType),
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			lidState:        power.OpenedLidState,
+			expectedProfile: "",
+			description:     "Profile with lid state requirement should be discarded when lid state doesn't match",
+		},
+		{
+			name: "complex_multi_monitor_matching",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"triple_monitor": {
+					Name: "triple_monitor",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+							{Description: utils.StringPtr("LG.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "Dell Monitor 27inch"},
+				{Name: "DP-2", ID: utils.IntPtr(2), Description: "LG UltraWide"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "triple_monitor",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("eDP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+				1: {Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(
+					true), MatchNameUsingRegex: utils.JustPtr(false)},
+				2: {
+					Description: utils.StringPtr("LG.*"), MatchDescriptionUsingRegex: utils.JustPtr(true),
+					MatchNameUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Should match profile requiring three different monitors with various matching criteria",
+		},
+		{
+			name: "monitor_reuse_prevented_in_scoring_0",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"requires_two_dell": {
+					Name: "requires_two_dell",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Dell Monitor A"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Should not match when one monitor matches the same regex pattern",
+		},
+		{
+			name: "monitor_reuse_prevented_in_scoring",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"requires_two_dell": {
+					Name: "requires_two_dell",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Dell Monitor A"},
+				{Name: "DP-2", ID: utils.IntPtr(1), Description: "Dell Monitor B"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "requires_two_dell",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(
+					true), MatchNameUsingRegex: utils.JustPtr(false)},
+				1: {Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(
+					true), MatchNameUsingRegex: utils.JustPtr(false)},
+			},
+			description: "Should match when two different monitors both match the same regex pattern",
+		},
+		{
+			name: "monitor_reuse_causes_partial_match",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"requires_two_dell": {
+					Name: "requires_two_dell",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+							{Description: utils.StringPtr("Dell.*"), MatchDescriptionUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Dell Monitor A"},
+				{Name: "DP-2", ID: utils.IntPtr(1), Description: "LG Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Should not match when only one monitor matches a rule that requires two matches",
+		},
+		{
+			name: "combined_power_and_lid_state_matching",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"battery_lid_closed": {
+					Name: "battery_lid_closed",
+					Conditions: &config.ProfileCondition{
+						PowerState: utils.JustPtr(config.BAT),
+						LidState:   utils.JustPtr(config.ClosedLidStateType),
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+				"just_external": {
+					Name: "just_external",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "External Monitor"},
+			},
+			powerState:      power.BatteryPowerState,
+			lidState:        power.ClosedLidState,
+			expectedProfile: "battery_lid_closed",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name: utils.StringPtr("DP-1"), MatchNameUsingRegex: utils.JustPtr(false),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Profile matching both power state and lid state should score higher than just monitor match",
+		},
+		{
+			name: "regex_description_multiple_matches_picks_best",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"dell_preference": {
+					Name: "dell_preference",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                       utils.StringPtr("DP-1"),
+								Description:                utils.StringPtr("Dell.*"),
+								MatchDescriptionUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Samsung Monitor"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "Dell Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "dell_preference",
+			description:     "When multiple monitors have same name, should pick the one that also matches description regex",
+		},
+		{
+			name: "empty_monitors_no_match",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"any_monitor": {
+					Name: "any_monitor",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{},
+			powerState:        power.ACPowerState,
+			expectedProfile:   "",
+			description:       "Should not match any profile when no monitors are connected",
+		},
+		{
+			name: "regex_name",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"regex": {
+					Name: "regex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-.*"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "regex",
+			description:     "Name matches by regex",
+		},
+		{
+			name: "no_regex_name",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"noregex": {
+					Name: "noregex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-.*")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Name does not match if regex flag is not provided",
+		},
+		{
+			name: "regex_name_and_description_combined",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"regex_both": {
+					Name: "regex_both",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                       utils.StringPtr("DP-[0-9]+"),
+								Description:                utils.StringPtr("Dell.*"),
+								MatchNameUsingRegex:        utils.JustPtr(true),
+								MatchDescriptionUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Dell Monitor 27inch"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "regex_both",
+			description:     "Both name and description match by regex on same monitor",
+		},
+		{
+			name: "regex_name_multiple_matches",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"multi_dp": {
+					Name: "multi_dp",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Monitor A"},
+				{Name: "DP-2", ID: utils.IntPtr(1), Description: "Monitor B"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "multi_dp",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name:                       utils.StringPtr("DP-[0-9]+"),
+					MatchNameUsingRegex:        utils.JustPtr(true),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+				1: {
+					Name:                       utils.StringPtr("DP-[0-9]+"),
+					MatchNameUsingRegex:        utils.JustPtr(true),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Should match when two different monitors both match the same name regex pattern",
+		},
+		{
+			name: "regex_name_partial_match_only_one",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"multi_dp": {
+					Name: "multi_dp",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Monitor A"},
+				{Name: "HDMI-1", ID: utils.IntPtr(1), Description: "Monitor B"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "",
+			description:     "Should not match when only one monitor matches a name regex that requires two matches",
+		},
+		{
+			name: "regex_name_picks_best_match",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"best_dp": {
+					Name: "best_dp",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                utils.StringPtr("DP-[0-9]+"),
+								Description:         utils.StringPtr("Dell Monitor"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Generic Monitor"},
+				{Name: "DP-2", ID: utils.IntPtr(1), Description: "Dell Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "best_dp",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				1: {
+					Name:                       utils.StringPtr("DP-[0-9]+"),
+					Description:                utils.StringPtr("Dell Monitor"),
+					MatchNameUsingRegex:        utils.JustPtr(true),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "When multiple monitors match name regex, should pick the one that also matches description",
+		},
+		{
+			name: "mixed_regex_and_exact_name_matching",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"mixed": {
+					Name: "mixed",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},                                               // Exact match
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)}, // Regex match
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "mixed",
+			description:     "Should match profile with mix of exact and regex name matching",
+		},
+		{
+			name: "regex_name_with_exact_description",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"hybrid": {
+					Name: "hybrid",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                utils.StringPtr("DP-[0-9]+"),
+								Description:         utils.StringPtr("Dell Monitor"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Dell Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "hybrid",
+			description:     "Should match when name is regex but description is exact match",
+		},
+		{
+			name: "complex_single_monitor_profiles_most_specific_wins",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"name_only": {
+					Name: "name_only",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+				"desc_only": {
+					Name: "desc_only",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Description: utils.StringPtr("Built-in Display")},
+						},
+					},
+				},
+				"name_and_desc": {
+					Name: "name_and_desc",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("Built-in Display"),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "name_and_desc",
+			description:     "With two monitors, most specific single-monitor profile (name+desc=15pts) should win over less specific (name=10pts, desc=5pts)",
+		},
+		{
+			name: "complex_mixed_single_and_dual_monitor_profiles",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"single_name": {
+					Name: "single_name",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+						},
+					},
+				},
+				"single_name_desc": {
+					Name: "single_name_desc",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("Built-in Display"),
+							},
+						},
+					},
+				},
+				"dual_names": {
+					Name: "dual_names",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+				"dual_names_descs": {
+					Name: "dual_names_descs",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("Built-in Display"),
+								MonitorTag:  utils.JustPtr("edp"),
+							},
+							{
+								Name:        utils.StringPtr("DP-1"),
+								Description: utils.StringPtr("External Monitor"),
+								MonitorTag:  utils.JustPtr("dp"),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External Monitor"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "dual_names_descs",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name:                       utils.StringPtr("eDP-1"),
+					Description:                utils.StringPtr("Built-in Display"),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+					MatchNameUsingRegex:        utils.JustPtr(false),
+					MonitorTag:                 utils.JustPtr("edp"),
+				},
+				1: {
+					Name:                       utils.StringPtr("DP-1"),
+					Description:                utils.StringPtr("External Monitor"),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+					MatchNameUsingRegex:        utils.JustPtr(false),
+					MonitorTag:                 utils.JustPtr("dp"),
+				},
+			},
+			description: "Dual monitor profile with names+descs (30pts) should win over single monitor profiles (10-15pts) and dual names only (20pts)",
+		},
+		{
+			name: "complex_single_vs_dual_single_wins_when_one_monitor",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"single_full": {
+					Name: "single_full",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:        utils.StringPtr("eDP-1"),
+								Description: utils.StringPtr("Built-in Display"),
+							},
+						},
+					},
+				},
+				"dual_monitors": {
+					Name: "dual_monitors",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "single_full",
+			description:     "Single monitor profile should match when only one monitor connected, dual monitor profile gets partial match and is discarded",
+		},
+		{
+			name: "complex_profiles_with_regex_vs_exact",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"exact_match": {
+					Name: "exact_match",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-1")},
+							{Name: utils.StringPtr("DP-2")},
+						},
+					},
+				},
+				"regex_match": {
+					Name: "regex_match",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+							{Name: utils.StringPtr("DP-[0-9]+"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+				"regex_with_desc": {
+					Name: "regex_with_desc",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                utils.StringPtr("DP-[0-9]+"),
+								Description:         utils.StringPtr("Monitor A"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+							{
+								Name:                utils.StringPtr("DP-[0-9]+"),
+								Description:         utils.StringPtr("Monitor B"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "DP-1", ID: utils.IntPtr(0), Description: "Monitor A"},
+				{Name: "DP-2", ID: utils.IntPtr(1), Description: "Monitor B"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "regex_with_desc",
+			expectedMonitorToRule: map[int]*config.RequiredMonitor{
+				0: {
+					Name:                       utils.StringPtr("DP-[0-9]+"),
+					Description:                utils.StringPtr("Monitor A"),
+					MatchNameUsingRegex:        utils.JustPtr(true),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+				1: {
+					Name:                       utils.StringPtr("DP-[0-9]+"),
+					Description:                utils.StringPtr("Monitor B"),
+					MatchNameUsingRegex:        utils.JustPtr(true),
+					MatchDescriptionUsingRegex: utils.JustPtr(false),
+				},
+			},
+			description: "Regex profile with descriptions (30pts) should win over exact match (20pts) and regex without desc (20pts)",
+		},
+		{
+			name: "complex_with_power_state_tiebreaker",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"dual_no_power": {
+					Name: "dual_no_power",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+				"dual_with_power": {
+					Name: "dual_with_power",
+					Conditions: &config.ProfileCondition{
+						PowerState: utils.JustPtr(config.BAT),
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External Monitor"},
+			},
+			powerState:      power.BatteryPowerState,
+			expectedProfile: "dual_with_power",
+			description:     "Profile matching power state (23pts) should win over same monitors without power state (20pts)",
+		},
+		{
+			name: "complex_three_monitors_partial_matches",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"all_three": {
+					Name: "all_three",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+							{Name: utils.StringPtr("DP-2")},
+						},
+					},
+				},
+				"first_two": {
+					Name: "first_two",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-1")},
+							{Name: utils.StringPtr("DP-1")},
+						},
+					},
+				},
+				"last_two": {
+					Name: "last_two",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("DP-1")},
+							{Name: utils.StringPtr("DP-2")},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "Monitor 1"},
+				{Name: "DP-2", ID: utils.IntPtr(2), Description: "Monitor 2"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "all_three",
+			description:     "Profile matching all three monitors (30pts) should win over profiles matching only two (20pts each)",
+		},
+		{
+			name: "complex_overlapping_regex_patterns",
+			config: createTestConfig(t, map[string]*config.Profile{
+				"broad_regex": {
+					Name: "broad_regex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr(".*"), MatchNameUsingRegex: utils.JustPtr(true)},
+							{Name: utils.StringPtr(".*"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+				"specific_regex": {
+					Name: "specific_regex",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{Name: utils.StringPtr("eDP-.*"), MatchNameUsingRegex: utils.JustPtr(true)},
+							{Name: utils.StringPtr("DP-.*"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+				"specific_with_desc": {
+					Name: "specific_with_desc",
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                utils.StringPtr("eDP-.*"),
+								Description:         utils.StringPtr("Built-in Display"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+							{Name: utils.StringPtr("DP-.*"), MatchNameUsingRegex: utils.JustPtr(true)},
+						},
+					},
+				},
+			}).Get(),
+			connectedMonitors: []*hypr.MonitorSpec{
+				{Name: "eDP-1", ID: utils.IntPtr(0), Description: "Built-in Display"},
+				{Name: "DP-1", ID: utils.IntPtr(1), Description: "External"},
+			},
+			powerState:      power.ACPowerState,
+			expectedProfile: "specific_with_desc",
+			description:     "Most specific regex with description (25pts) should win over less specific regex patterns (20pts each)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matcher := NewMatcher()
+			matcher := matchers.NewMatcher()
 
 			found, result, err := matcher.Match(tt.config.Get(), tt.connectedMonitors, tt.powerState, tt.lidState)
 			if err != nil {
@@ -356,13 +1254,21 @@ func TestMatcher_Match(t *testing.T) {
 
 			if tt.expectedProfile == "" {
 				if result != nil || found {
-					t.Errorf("Expected no profile match, but got profile: %s", result.Name)
+					t.Errorf("Expected no profile match, but got profile: %s", result.Profile.Name)
 				}
 			} else {
 				if result == nil || !found {
 					t.Errorf("Expected profile %s, but got no match", tt.expectedProfile)
-				} else if result.Name != tt.expectedProfile {
-					t.Errorf("Expected profile %s, but got %s", tt.expectedProfile, result.Name)
+				} else if result.Profile.Name != tt.expectedProfile {
+					t.Errorf("Expected profile %s, but got %s",
+						tt.expectedProfile, result.Profile.Name)
+				}
+
+				// Validate MonitorToRule mapping if expected values are provided
+				if tt.expectedMonitorToRule != nil {
+					assert.Equal(t, normalizeMonitorToRule(tt.expectedMonitorToRule),
+						normalizeMonitorToRule(result.MonitorToRule),
+						"MonitorToRule mapping should match expected")
 				}
 			}
 
@@ -379,4 +1285,31 @@ func createTestConfig(t *testing.T, profiles map[string]*config.Profile) *testut
 		PowerStateMatch:  utils.IntPtr(3),
 		LidStateMatch:    utils.IntPtr(3),
 	})
+}
+
+// Helper to normalize RequiredMonitor for comparison (strips compiled regex)
+func normalizeRequiredMonitor(rm *config.RequiredMonitor) *config.RequiredMonitor {
+	if rm == nil {
+		return nil
+	}
+	return &config.RequiredMonitor{
+		Name:                       rm.Name,
+		Description:                rm.Description,
+		MonitorTag:                 rm.MonitorTag,
+		MatchDescriptionUsingRegex: rm.MatchDescriptionUsingRegex,
+		MatchNameUsingRegex:        rm.MatchNameUsingRegex,
+		// Intentionally omit DescriptionRegex and NameRegex
+	}
+}
+
+// Helper to normalize MonitorToRule map for comparison
+func normalizeMonitorToRule(m map[int]*config.RequiredMonitor) map[int]*config.RequiredMonitor {
+	if m == nil {
+		return nil
+	}
+	normalized := make(map[int]*config.RequiredMonitor)
+	for k, v := range m {
+		normalized[k] = normalizeRequiredMonitor(v)
+	}
+	return normalized
 }

--- a/internal/matchers/types.go
+++ b/internal/matchers/types.go
@@ -1,0 +1,28 @@
+package matchers
+
+import "github.com/fiffeek/hyprdynamicmonitors/internal/config"
+
+type MatchedProfile struct {
+	Profile       *config.Profile
+	MonitorToRule map[int]*config.RequiredMonitor
+}
+
+func NewMatchedProfile(profile *config.Profile, monitorToRule map[int]*config.RequiredMonitor) *MatchedProfile {
+	if profile == nil {
+		return nil
+	}
+	return &MatchedProfile{
+		profile,
+		monitorToRule,
+	}
+}
+
+func NewFallbackProfile(profile *config.Profile) *MatchedProfile {
+	if profile == nil {
+		return nil
+	}
+	return &MatchedProfile{
+		profile,
+		make(map[int]*config.RequiredMonitor),
+	}
+}

--- a/internal/tui/hdm_config_pane_test.go
+++ b/internal/tui/hdm_config_pane_test.go
@@ -118,7 +118,7 @@ func TestHDMConfigPane_Update(t *testing.T) {
 			if tt.expectProfileReset {
 				profile := pane.GetProfile()
 				if profile != nil {
-					assert.Equal(t, cfg.Get().Profiles["test"], profile)
+					assert.Equal(t, cfg.Get().Profiles["test"], profile.Profile)
 				}
 			} else {
 				assert.Equal(t, oldProfile, pane.GetProfile())

--- a/internal/tui/hdm_profile_preview_test.go
+++ b/internal/tui/hdm_profile_preview_test.go
@@ -81,7 +81,7 @@ func TestHDMProfilePreview_Update(t *testing.T) {
 			assert.Equal(t, tt.expectedLidState, preview.GetLidState())
 
 			if tt.expectProfileReset {
-				assert.Equal(t, cfgProfile, preview.GetProfile())
+				assert.Equal(t, cfgProfile, preview.GetProfile().Profile)
 				assert.Equal(t, content, preview.GetText())
 			} else {
 				assert.Equal(t, oldProfile, preview.GetProfile())

--- a/internal/tui/hypr_apply.go
+++ b/internal/tui/hypr_apply.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/generators"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/matchers"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/power"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/profilemaker"
 	"github.com/sirupsen/logrus"
@@ -57,7 +58,7 @@ func (h *HyprApply) EditProfile(monitors []*MonitorSpec, name string) tea.Cmd {
 	return OperationStatusCmd(OperationNameEditProfile, err)
 }
 
-func (h *HyprApply) GenerateThroughHDM(cfg *config.Config, profile *config.Profile,
+func (h *HyprApply) GenerateThroughHDM(cfg *config.Config, profile *matchers.MatchedProfile,
 	monitors []*MonitorSpec, powerState power.PowerState, lidState power.LidState,
 ) tea.Cmd {
 	if profile == nil {

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/matchers"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/power"
 )
 
@@ -332,12 +332,12 @@ type CloseColorPickerCommand struct{}
 type CloseMonitorModeListCommand struct{}
 
 type RenderHDMConfigCommand struct {
-	profile    *config.Profile
+	profile    *matchers.MatchedProfile
 	lidState   power.LidState
 	powerState power.PowerState
 }
 
-func RenderHDMConfigCmd(profile *config.Profile, lidState power.LidState, powerState power.PowerState) tea.Cmd {
+func RenderHDMConfigCmd(profile *matchers.MatchedProfile, lidState power.LidState, powerState power.PowerState) tea.Cmd {
 	return func() tea.Msg {
 		return RenderHDMConfigCommand{
 			profile,

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -826,7 +826,12 @@ func TestModel_Update_UserFlows(t *testing.T) {
 						require.NotNil(t, profile, "profile 'h' should not be nil")
 						require.NotNil(t, profile.Conditions, "profile 'h' conditions should not be nil")
 						assert.Equal(t, []*config.RequiredMonitor{
-							{Name: utils.JustPtr("HEADLESS-2"), MonitorTag: utils.JustPtr("monitor1")},
+							{
+								Name:                       utils.JustPtr("HEADLESS-2"),
+								MonitorTag:                 utils.JustPtr("monitor1"),
+								MatchDescriptionUsingRegex: utils.JustPtr(false),
+								MatchNameUsingRegex:        utils.JustPtr(false),
+							},
 						}, profile.Conditions.RequiredMonitors)
 					},
 				},
@@ -868,10 +873,31 @@ func TestModel_Update_UserFlows(t *testing.T) {
 						require.NotNil(t, profile, "profile 'h' should not be nil")
 						require.NotNil(t, profile.Conditions, "profile 'h' conditions should not be nil")
 						assert.Equal(t, []*config.RequiredMonitor{
-							{Description: utils.JustPtr("BOE NE135A1M-NY1"), MonitorTag: utils.JustPtr("monitor0")},
-							{Description: utils.JustPtr("Dell Inc. DELL U2723QE 5YNK3H3"), MonitorTag: utils.JustPtr("monitor1")},
-							{Description: utils.JustPtr("Samsung Electric Company C27F390 HTHK500315"), MonitorTag: utils.JustPtr("monitor2")},
-							{Description: utils.JustPtr("Headless Virtual Display"), MonitorTag: utils.JustPtr("monitor3")},
+							{
+								Description:                utils.JustPtr("BOE NE135A1M-NY1"),
+								MonitorTag:                 utils.JustPtr("monitor0"),
+								MatchDescriptionUsingRegex: utils.JustPtr(false),
+								MatchNameUsingRegex:        utils.JustPtr(false),
+							},
+							{
+								Description:                utils.JustPtr("Dell Inc. DELL U2723QE 5YNK3H3"),
+								MonitorTag:                 utils.JustPtr("monitor1"),
+								MatchDescriptionUsingRegex: utils.JustPtr(false),
+								MatchNameUsingRegex:        utils.JustPtr(false),
+							},
+							{
+								Description: utils.JustPtr(
+									"Samsung Electric Company C27F390 HTHK500315"),
+								MonitorTag:                 utils.JustPtr("monitor2"),
+								MatchDescriptionUsingRegex: utils.JustPtr(false),
+								MatchNameUsingRegex:        utils.JustPtr(false),
+							},
+							{
+								Description:                utils.JustPtr("Headless Virtual Display"),
+								MonitorTag:                 utils.JustPtr("monitor3"),
+								MatchDescriptionUsingRegex: utils.JustPtr(false),
+								MatchNameUsingRegex:        utils.JustPtr(false),
+							},
 						}, profile.Conditions.RequiredMonitors)
 					},
 				},

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -106,6 +106,39 @@ func Test__Run_Binary(t *testing.T) {
 		},
 
 		{
+			name:        "basic templating regex",
+			description: "when hypr returns the same monitors as defined in the configuration, the template should match the golden file with a regex",
+			config: createBasicTestConfig(t).WithProfiles(map[string]*config.Profile{
+				"both": {
+					ConfigType: utils.JustPtr(config.Template),
+					Conditions: &config.ProfileCondition{
+						RequiredMonitors: []*config.RequiredMonitor{
+							{
+								Name:                utils.StringPtr("eDP.*"),
+								MonitorTag:          utils.StringPtr("EDP"),
+								MatchNameUsingRegex: utils.JustPtr(true),
+							},
+							{
+								Description:                utils.JustPtr("LG.*"),
+								MonitorTag:                 utils.StringPtr("DP"),
+								MatchDescriptionUsingRegex: utils.JustPtr(true),
+							},
+						},
+					},
+				},
+			}).FillProfileConfigFile("both", "testdata/app/templates/basic.toml"),
+			hyprMonitorResponseFiles: []string{"testdata/hypr/server/basic_monitors.json"},
+			validateSideEffects: func(t *testing.T, cfg *config.RawConfig) {
+				testutils.AssertFileExists(t, *cfg.General.Destination)
+				compareWithFixture(t, *cfg.General.Destination,
+					"testdata/app/fixtures/basic_both_regex.conf")
+			},
+			disablePowerEvents: true,
+			disableHotReload:   true,
+			runOnce:            true,
+		},
+
+		{
 			name:        "headless templating",
 			description: "when hypr returns the headless monitors defined in the configuration, the template should match the golden file",
 			config: createBasicTestConfig(t).WithProfiles(map[string]*config.Profile{
@@ -553,12 +586,17 @@ func Test__Run_Binary(t *testing.T) {
 					PowerState: nil,
 					RequiredMonitors: []*config.RequiredMonitor{
 						{
-							Description: utils.StringPtr("BOE NE135A1M-NY1"),
-							MonitorTag:  utils.StringPtr("monitor0"),
+							Description:                utils.StringPtr("BOE NE135A1M-NY1"),
+							MonitorTag:                 utils.StringPtr("monitor0"),
+							MatchDescriptionUsingRegex: utils.JustPtr(false),
+							MatchNameUsingRegex:        utils.JustPtr(false),
 						},
 						{
-							Description: utils.StringPtr("LG Electronics LG SDQHD 301NTBKDU037"),
-							MonitorTag:  utils.StringPtr("monitor1"),
+							Description: utils.StringPtr(
+								"LG Electronics LG SDQHD 301NTBKDU037"),
+							MonitorTag:                 utils.StringPtr("monitor1"),
+							MatchDescriptionUsingRegex: utils.JustPtr(false),
+							MatchNameUsingRegex:        utils.JustPtr(false),
 						},
 					},
 				}, profile.Conditions)

--- a/test/testdata/app/fixtures/basic_both_regex.conf
+++ b/test/testdata/app/fixtures/basic_both_regex.conf
@@ -1,0 +1,7 @@
+# Template test configuration
+# Generated with power state: AC
+# Generated with lid state: Opened
+monitor=eDP-1,BOE NE135A1M-NY1
+monitor=DP-11,LG Electronics LG SDQHD 301NTBKDU037
+DP=DP-11,LG Electronics LG SDQHD 301NTBKDU037
+EDP=eDP-1,BOE NE135A1M-NY1


### PR DESCRIPTION
## What does this PR do?
Allows for using regex in description and monitor names in the config (explicitly defined flags to change the default matching behavior). 

## Why is this change important?

Requested by the users in #101 .

## How to test this PR locally?

`make pre-push`

## Related issues

Closes #101 
