### PR TITLE
fix(hypr): do not panic when unix socket connection cant be made

### DIFF
--- a/internal/hypr/ipc.go
+++ b/internal/hypr/ipc.go
@@ -154,10 +154,10 @@ func (h *IPC) queryConnectedMonitors(ctx context.Context) (MonitorSpecs, error) 
 	logrus.Debug("Querying connected monitors")
 	socketPath := GetHyprSocket(h.xdgRuntimeDir, h.instanceSignature)
 	conn, teardown, err := dial.GetUnixSocketConnection(ctx, socketPath)
-	defer teardown()
 	if err != nil {
 		return nil, fmt.Errorf("cant open socket to %s: %w", socketPath, err)
 	}
+	defer teardown()
 
 	return dial.SyncQuerySocket[MonitorSpecs](conn, "j/monitors all\n")
 }


### PR DESCRIPTION


## What does this PR do?

teardown was used prior to infering it's non-nil

## How to test this PR locally?

`make pre-push`

## Related issues

<!--
Closes #234
-->
