### PR TITLE
chore(ci): extract nix testing to its own workflow file

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,43 @@
+---
+name: Nix
+
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - flake.nix
+            - flake.lock
+            - go.mod
+            - go.sum
+            - .github/workflows/nix.yaml
+            - nix/**
+    pull_request:
+        branches:
+            - main
+        paths:
+            - flake.nix
+            - flake.lock
+            - go.mod
+            - go.sum
+            - .github/workflows/nix.yaml
+            - nix/**
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - uses: DeterminateSystems/nix-installer-action@main
+
+            - uses: DeterminateSystems/magic-nix-cache-action@main
+
+            - name: Test Nix build
+              run: |
+                  nix flake check
+                  nix build
+                  ./result/bin/hyprdynamicmonitors --version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,21 +94,3 @@ jobs:
               with:
                   files: ./coverage.xml
                   token: ${{ secrets.CODECOV_TOKEN }}
-
-    nix:
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - uses: DeterminateSystems/nix-installer-action@main
-
-            - uses: DeterminateSystems/magic-nix-cache-action@main
-
-            - name: Test Nix build
-              run: |
-                  nix flake check
-                  nix build
-                  ./result/bin/hyprdynamicmonitors --version


### PR DESCRIPTION
## What does this PR do?

allows to selectively run the nix bulid ci workflow (only if related files are changed)

## Why is this change important?

do not need to waste the CI time on unrelated changes

