### PR TITLE
feat(generators): validate go template files on start-up and config reloads

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"flag"
-	"fmt"
-	"strings"
-
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/generators"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -17,14 +15,16 @@ var validateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logrus.WithField("config_path", configPath).Debug("Validating configuration")
 
-		_, err := config.NewConfig(configPath)
+		cfg, err := config.NewConfig(configPath)
 		if err != nil {
-			parts := strings.Split(err.Error(), ": ")
-			indent := 0
-			for _, part := range parts {
-				fmt.Fprintf(flag.CommandLine.Output(), "%s%s\n", strings.Repeat(" ", indent), part)
-				indent += 2
-			}
+			utils.PrettyPrintError(err)
+			logrus.Fatal("Configuration validation failed")
+			return
+		}
+
+		_, err = generators.NewConfigGenerator(cfg)
+		if err != nil {
+			utils.PrettyPrintError(err)
 			logrus.Fatal("Configuration validation failed")
 			return
 		}

--- a/examples/template-variables/hyprconfigs/gaming-template.conf.tmpl
+++ b/examples/template-variables/hyprconfigs/gaming-template.conf.tmpl
@@ -9,7 +9,7 @@ misc {
 {{- end }}
 
 # Gaming-specific settings using custom variables
-{{- if eq .TemplateVariables.gaming_mode "true" }}
+{{- if eq .gaming_mode "true" }}
 decoration {
   blur {
     enabled = false  # Disable blur for performance

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -78,14 +78,17 @@ func NewApplication(
 
 	matcher := matchers.NewMatcher()
 
-	generator := generators.NewConfigGenerator(cfg)
+	generator, err := generators.NewConfigGenerator(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("can't create config generator, likely an issue with one of the template files: %w", err)
+	}
 	notifications := notifications.NewService(cfg)
 
 	svc := userconfigupdater.NewService(cfg, hyprIPC, powerDetector, &userconfigupdater.Config{
 		DryRun: *dryRun,
 	}, matcher, generator, notifications, lidDetector)
 
-	reloader := reloader.NewService(cfg, fswatcher, powerDetector, svc, *disableAutoHotReload, lidDetector)
+	reloader := reloader.NewService(cfg, fswatcher, powerDetector, svc, *disableAutoHotReload, lidDetector, generator)
 
 	signalHandler := signal.NewHandler(cancel, reloader, svc)
 

--- a/internal/app/tui.go
+++ b/internal/app/tui.go
@@ -95,7 +95,11 @@ func NewTUI(ctx context.Context, configPath, mockedHyprMonitors string,
 		lidState = ld.GetCurrentState()
 	}
 
-	model := tui.NewModel(cfg, monitors, profileMaker, version, currentState, nil, runningUnderTest, lidState)
+	model, err := tui.NewModel(cfg, monitors, profileMaker, version, currentState, nil, runningUnderTest, lidState)
+	if err != nil {
+		return nil, fmt.Errorf("can't create the TUI model: %w", err)
+	}
+
 	program := tea.NewProgram(
 		model,
 		tea.WithAltScreen(),

--- a/internal/generators/config_generator_test.go
+++ b/internal/generators/config_generator_test.go
@@ -19,7 +19,8 @@ import (
 
 func TestConfigGenerator_GenerateConfig_Static(t *testing.T) {
 	cfg := testutils.NewTestConfig(t).Get()
-	generator := generators.NewConfigGenerator(cfg)
+	generator, err := generators.NewConfigGenerator(cfg)
+	require.NoError(t, err, "config generators should be able to init")
 
 	tempDir := t.TempDir()
 	destination := filepath.Join(tempDir, "hyprland.conf")
@@ -88,7 +89,8 @@ func TestConfigGenerator_GenerateConfig_Template(t *testing.T) {
 		"overwritten_value": "this_shall_be_overwritten",
 		"general_value":     "general",
 	}).Get()
-	generator := generators.NewConfigGenerator(cfg)
+	generator, err := generators.NewConfigGenerator(cfg)
+	require.NoError(t, err, "config generators should be able to init")
 
 	tempDir := t.TempDir()
 	destination := filepath.Join(tempDir, "hyprland.conf")

--- a/internal/tui/root.go
+++ b/internal/tui/root.go
@@ -59,7 +59,7 @@ type Model struct {
 func NewModel(cfg *config.Config, hyprMonitors hypr.MonitorSpecs,
 	profileMaker *profilemaker.Service, version string, powerState power.PowerState,
 	duration *time.Duration, runningUnderTest bool, lidState power.LidState,
-) Model {
+) (Model, error) {
 	monitors := make([]*MonitorSpec, len(hyprMonitors))
 	for i, monitor := range hyprMonitors {
 		monitors[i] = NewMonitorSpec(monitor)
@@ -67,7 +67,11 @@ func NewModel(cfg *config.Config, hyprMonitors hypr.MonitorSpecs,
 
 	state := NewState(monitors, cfg)
 	matcher := matchers.NewMatcher()
-	generator := generators.NewConfigGenerator(cfg)
+	generator, err := generators.NewConfigGenerator(cfg)
+	if err != nil {
+		return Model{}, fmt.Errorf("can't create config generator, likely an issue with one of the template files: %w", err)
+	}
+
 	colors := NewColorsManager(cfg)
 
 	model := Model{
@@ -97,7 +101,7 @@ func NewModel(cfg *config.Config, hyprMonitors hypr.MonitorSpecs,
 		colors:                    colors,
 	}
 
-	return model
+	return model, nil
 }
 
 func (m Model) Init() tea.Cmd {

--- a/internal/tui/root_test.go
+++ b/internal/tui/root_test.go
@@ -1232,8 +1232,9 @@ func TestModel_Update_UserFlows(t *testing.T) {
 				tt.cfg = testutils.NewTestConfig(t).Get()
 			}
 			pm := profilemaker.NewService(tt.cfg, nil)
-			model := tui.NewModel(tt.cfg,
+			model, err := tui.NewModel(tt.cfg,
 				hyprMonitors, pm, "test-version", tt.powerState, tt.runFor, true, tt.lidState)
+			require.NoError(t, err, "should spawn the model")
 			tm := teatest.NewTestModel(t, model, teatest.WithInitialTermSize(160, 45))
 
 			// wait for app to be `ready`, just check if the footer is up

--- a/internal/utils/error_pretty.go
+++ b/internal/utils/error_pretty.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+func PrettyPrintError(err error) {
+	parts := strings.Split(err.Error(), ": ")
+	indent := 0
+	for _, part := range parts {
+		fmt.Fprintf(flag.CommandLine.Output(), "%s%s\n", strings.Repeat(" ", indent), part)
+		indent += 2
+	}
+}

--- a/test/testdata/app/configs/invalid/hyprconfigs/invalid_syntax.go.tmpl
+++ b/test/testdata/app/configs/invalid/hyprconfigs/invalid_syntax.go.tmpl
@@ -1,0 +1,1 @@
+{{ .opened_but_not_closed }

--- a/test/testdata/app/configs/invalid/hyprconfigs/invalid_syntax_func.go.tmpl
+++ b/test/testdata/app/configs/invalid/hyprconfigs/invalid_syntax_func.go.tmpl
@@ -1,0 +1,8 @@
+# imagine a typo in the function name
+{{ if isOnWhatever }}
+# disable animations, reduce refresh rate, enable vrr
+monitor={{ $laptop.Name }},2880x1920@60.00000,0x0,2.0,vrr,1
+animations {
+  enabled = false
+}
+{{- end}}

--- a/test/testdata/app/configs/invalid/invalid_template.toml
+++ b/test/testdata/app/configs/invalid/invalid_template.toml
@@ -1,0 +1,6 @@
+[profiles.laptop_only]
+config_file = "hyprconfigs/invalid_syntax.go.tmpl"
+config_file_type = "template"
+
+[[profiles.laptop_only.conditions.required_monitors]]
+name = "eDP-1"

--- a/test/testdata/app/configs/invalid/invalid_template_func.toml
+++ b/test/testdata/app/configs/invalid/invalid_template_func.toml
@@ -1,0 +1,6 @@
+[profiles.laptop_only]
+config_file = "hyprconfigs/invalid_syntax_func.go.tmpl"
+config_file_type = "template"
+
+[[profiles.laptop_only.conditions.required_monitors]]
+name = "eDP-1"

--- a/test/testdata/app/configs/valid/hyprconfigs/valid_syntax.go.tmpl
+++ b/test/testdata/app/configs/valid/hyprconfigs/valid_syntax.go.tmpl
@@ -1,0 +1,18 @@
+# validate should just check the syntax and functions, using "undefined" vars is fine
+# --dry-run should be checking runtime of these per profile
+{{- range .Monitors }}
+{{- if eq .Tag "laptop" }}
+monitor = {{ .Name }}, 1920x1080@{{ $.refresh_rate_ac }}, 0x0, {{ $.default_scaling }}
+{{- else if eq .Tag "external" }}
+monitor = {{ .Name }}, 1920x1080@60, 1080x0, {{ $.external_scaling }}
+{{- end }}
+{{- end }}
+
+# Workspace layout based on template variable
+{{- if eq .workspace_layout "extended" }}
+workspace = 1, monitor:eDP-1
+workspace = 2, monitor:DP-11
+{{- end }}
+
+{{ $.whatever }}
+{{ .undefinedVar }}

--- a/test/testdata/app/configs/valid/static_vars.toml
+++ b/test/testdata/app/configs/valid/static_vars.toml
@@ -1,0 +1,6 @@
+[profiles.laptop_only]
+config_file = "hyprconfigs/valid_syntax.go.tmpl"
+config_file_type = "template"
+
+[[profiles.laptop_only.conditions.required_monitors]]
+name = "eDP-1"

--- a/test/testdata/app/configs/valid/valid_template.toml
+++ b/test/testdata/app/configs/valid/valid_template.toml
@@ -1,0 +1,10 @@
+[general]
+destination = "$HOME/.config/hypr/monitors.conf"
+
+[power_events]
+
+[power_events.dbus_query_object]
+path = "/org/freedesktop/UPower/devices/line_power_ACAD"
+
+[[power_events.dbus_signal_match_rules]]
+object_path = "/org/freedesktop/UPower/devices/line_power_ACAD"

--- a/test/validate_test.go
+++ b/test/validate_test.go
@@ -94,6 +94,21 @@ func Test_Validate_InvalidConfigs(t *testing.T) {
 			configFile:    "negative_scoring.toml",
 			expectedError: "score needs to be > 1",
 		},
+		{
+			name:          "invalid template",
+			configFile:    "invalid_template.toml",
+			expectedError: "unexpected \"}\" in operand",
+		},
+		{
+			name:          "invalid template func",
+			configFile:    "invalid_template_func.toml",
+			expectedError: "function \"isOnWhatever\" not defined",
+		},
+		{
+			name:               "valid template",
+			configFile:         "valid_template.toml",
+			doesNotExpectError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What does this PR do?

Adds templates validation on `hdm validate` and on config reloads.

## Why is this change important?

Will catch user errors closer to the start-up rather than runtime when the templates are rendered.

## How to test this PR locally?

`make pre-push`

## Related issues

Closes #123 
