### PR TITLE
feat: pass dry-run to config generators

### DIFF
--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TheCreeper/go-notify"
 	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/fiffeek/hyprdynamicmonitors/internal/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,9 +25,14 @@ func NewService(cfg *config.Config) *Service {
 	}
 }
 
-func (s *Service) NotifyProfileApplied(profile *config.Profile) error {
+func (s *Service) NotifyProfileApplied(profile *config.Profile, dryRun bool) error {
 	if *s.config.Get().Notifications.Disabled {
 		logrus.Debug("notifications are not enabled, not sending")
+		return nil
+	}
+	if dryRun {
+		logrus.WithFields(utils.NewLogrusEmptyFields().WithLogID(utils.DryRunNotificationLogID)).
+			Info("[DRY RUN] Would send notification")
 		return nil
 	}
 

--- a/internal/tui/hypr_apply.go
+++ b/internal/tui/hypr_apply.go
@@ -69,6 +69,6 @@ func (h *HyprApply) GenerateThroughHDM(cfg *config.Config, profile *matchers.Mat
 		return OperationStatusCmd(OperationNameHydrate, err)
 	}
 	destination := *cfg.Get().General.Destination
-	_, err = h.generator.GenerateConfig(cfg.Get(), profile, hyprMonitors, powerState, lidState, destination)
+	_, err = h.generator.GenerateConfig(cfg.Get(), profile, hyprMonitors, powerState, lidState, destination, false)
 	return OperationStatusCmd(OperationNameHydrate, err)
 }

--- a/internal/utils/logid.go
+++ b/internal/utils/logid.go
@@ -16,6 +16,10 @@ const (
 	PreExecLogID
 	PostExecLogID
 	DisablingPowerEventsLogID
+	DryRunSymlinkLogID
+	DryRunTemplateLogID
+	DryRunExedLogID
+	DryRunNotificationLogID
 )
 
 type LogrusCustomFields struct {


### PR DESCRIPTION
## What does this PR do?

Changes dry run to also:
- show the templated file contents
- show whether it would notify
- show the exec commands

## Why is this change important?

Easier testing with `hyprdynamicmonitors run --dry-run --run-once`

## How to test this PR locally?

`make pre-push`

## Related issues

Closes  #126 
