### PR TITLE
chore: disable git lfs on test workflows

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -8,6 +8,7 @@ on:
         paths:
             - docs/**
             - docs/*
+            - .github/workflows/docs-pr.yaml
 
 jobs:
     build:
@@ -17,13 +18,6 @@ jobs:
         steps:
             - name: Checkout repo
               uses: actions/checkout@v4
-              with:
-                  lfs: true
-
-            - name: Fetch and checkout LFS objects
-              run: |
-                  git lfs fetch --all
-                  git lfs checkout
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,12 +22,6 @@ jobs:
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  lfs: true
-
-            - name: Fetch and checkout LFS objects
-              run: |
-                  git lfs fetch --all
-                  git lfs checkout
 
             - name: Set up Go
               uses: actions/setup-go@v5


### PR DESCRIPTION
## What does this PR do?

Git LFS on github has bandwidth quota of 10GB, this is easily exhausted when testing, so let's disable it for the PRs -- still is pulled properly on releases and on documentation on `main`.
