### PR TITLE
docs: throw on invalid anchors during build phase

### DIFF
--- a/docs/docs/configuration/monitor-matching.md
+++ b/docs/docs/configuration/monitor-matching.md
@@ -164,7 +164,7 @@ description = "Dell.*"
 match_description_using_regex = true
 ```
 
-Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#scoring-system)) it would be picked up as the current setup.
+Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#customizing-scoring-weights)) it would be picked up as the current setup.
 
 Moreover, if you do assign tags, they are deterministic -- so for exactly the same setup (`monitor id` matters), same template would be produced.
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
   projectName: 'hyprdynamicmonitors',
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: "throw",
 
   i18n: {
     defaultLocale: 'en',

--- a/docs/versioned_docs/version-v1.3.10/configuration/monitor-matching.md
+++ b/docs/versioned_docs/version-v1.3.10/configuration/monitor-matching.md
@@ -164,7 +164,7 @@ description = "Dell.*"
 match_description_using_regex = true
 ```
 
-Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#scoring-system)) it would be picked up as the current setup.
+Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#customizing-scoring-weights)) it would be picked up as the current setup.
 
 Moreover, if you do assign tags, they are deterministic -- so for exactly the same setup (`monitor id` matters), same template would be produced.
 

--- a/docs/versioned_docs/version-v1.3.9/configuration/monitor-matching.md
+++ b/docs/versioned_docs/version-v1.3.9/configuration/monitor-matching.md
@@ -164,7 +164,7 @@ description = "Dell.*"
 match_description_using_regex = true
 ```
 
-Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#scoring-system)) it would be picked up as the current setup.
+Since one rule matches to one output, this profile will also match the current setup -- but since it defines more constrained rules (see [scoring](#customizing-scoring-weights)) it would be picked up as the current setup.
 
 Moreover, if you do assign tags, they are deterministic -- so for exactly the same setup (`monitor id` matters), same template would be produced.
 


### PR DESCRIPTION
## What does this PR do?

Throw on all invalid anchors during the build phase so that they are caught as early as possible.
