### PR TITLE
feat(config): add support for include directive in configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"bufio"
 	"bytes"
 	_ "embed"
 	"errors"
@@ -74,6 +75,7 @@ type RawConfig struct {
 	Notifications        *Notifications      `toml:"notifications"`
 	StaticTemplateValues map[string]string   `toml:"static_template_values"`
 	KeysOrder            []string            `toml:"-"`
+	IncludedFiles        []string            `toml:"-"`
 	TUISection           *TUISection         `toml:"tui"`
 }
 
@@ -422,14 +424,13 @@ func Load(configPath string) (*RawConfig, error) {
 	logrus.WithFields(logrus.Fields{"abs": absConfig}).Debug("Found absolute config path")
 
 	// nolint:gosec
-	contents, err := os.ReadFile(absConfig)
+	contents, includedFiles, err := processIncludes(absConfig, 0)
 	if err != nil {
-		return nil, fmt.Errorf("cant read config file %s: %w", absConfig, err)
+		return nil, fmt.Errorf("cant process config includes %s: %w", absConfig, err)
 	}
-	logrus.Debugf("Config contents: %s", contents)
 
 	var config RawConfig
-	m, err := toml.DecodeFile(configPath, &config)
+	m, err := toml.Decode(string(contents), &config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode TOML: %w", err)
 	}
@@ -441,6 +442,7 @@ func Load(configPath string) (*RawConfig, error) {
 	config.ConfigPath = absConfig
 	config.ConfigDirPath = filepath.Dir(config.ConfigPath)
 	config.KeysOrder = keys
+	config.IncludedFiles = includedFiles
 
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -1174,4 +1176,90 @@ func (d *DbusSignalReceiveFilter) Validate() error {
 	}
 
 	return nil
+}
+
+// Regex for single include: include = "path" or include = 'path'
+var reSingleInclude = regexp.MustCompile(`^\s*include\s*=\s*(?:"([^"]+)"|'([^']+)')\s*(?:#.*)?$`)
+
+// Regex for list include: include = ["path", "path2"]
+var reListInclude = regexp.MustCompile(`^\s*include\s*=\s*\[(.*)\]\s*(?:#.*)?$`)
+
+// Regex for quoted string inside list
+var reQuotedString = regexp.MustCompile(`(?:"([^"]+)"|'([^']+)')`)
+
+const MaxIncludeDepth = 20
+
+func processIncludes(path string, depth int) ([]byte, []string, error) {
+	if depth > MaxIncludeDepth {
+		return nil, nil, fmt.Errorf("include depth limit exceeded at %s (max %d)", path, MaxIncludeDepth)
+	}
+
+	path = os.ExpandEnv(path)
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't convert include path %s to absolute path: %w", path, err)
+	}
+
+	content, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't read include file %s: %w", absPath, err)
+	}
+
+	includedFiles := []string{absPath}
+	var result bytes.Buffer
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	dir := filepath.Dir(absPath)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if match := reSingleInclude.FindStringSubmatch(line); match != nil {
+			incPath := match[1]
+			if incPath == "" {
+				incPath = match[2]
+			}
+			if !filepath.IsAbs(incPath) {
+				incPath = filepath.Join(dir, incPath)
+			}
+			incContent, incFiles, err := processIncludes(incPath, depth+1)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to process single include '%s' from '%s': %w", incPath, absPath, err)
+			}
+			includedFiles = append(includedFiles, incFiles...)
+			result.Write(incContent)
+			result.WriteString("\n")
+			continue
+		}
+
+		if match := reListInclude.FindStringSubmatch(line); match != nil {
+			listContent := match[1]
+			matches := reQuotedString.FindAllStringSubmatch(listContent, -1)
+			for _, m := range matches {
+				incPath := m[1]
+				if incPath == "" {
+					incPath = m[2]
+				}
+				if !filepath.IsAbs(incPath) {
+					incPath = filepath.Join(dir, incPath)
+				}
+				incContent, incFiles, err := processIncludes(incPath, depth+1)
+				if err != nil {
+					return nil, nil, fmt.Errorf("failed to process list include '%s' from '%s': %w", incPath, absPath, err)
+				}
+				includedFiles = append(includedFiles, incFiles...)
+				result.Write(incContent)
+				result.WriteString("\n")
+			}
+			continue
+		}
+
+		result.WriteString(line)
+		result.WriteString("\n")
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, nil, fmt.Errorf("error reading file %s during include processing: %w", absPath, err)
+	}
+
+	return result.Bytes(), includedFiles, nil
 }

--- a/internal/config/include_test.go
+++ b/internal/config/include_test.go
@@ -1,0 +1,153 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fiffeek/hyprdynamicmonitors/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInclude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainContent := `
+[general]
+destination = "/tmp/dest"
+
+include = "extra_profiles.toml"
+
+[profiles.base]
+config_file = "base.conf"
+conditions.required_monitors = [{name = "DP-3"}]
+`
+	extraProfilesContent := `
+[profiles.extra]
+config_file = "extra.conf"
+conditions.required_monitors = [{name = "DP-1"}]
+
+include = "nested.toml"
+`
+
+	nestedContent := `
+[profiles.nested]
+config_file = "nested.conf"
+conditions.required_monitors = [{name = "DP-2"}]
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.toml"), []byte(mainContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "extra_profiles.toml"), []byte(extraProfilesContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nested.toml"), []byte(nestedContent), 0644))
+
+	// Create dummy config files
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "base.conf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "extra.conf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nested.conf"), []byte(""), 0644))
+
+	cfg, err := config.Load(filepath.Join(tmpDir, "main.toml"))
+	require.NoError(t, err)
+
+	assert.Contains(t, cfg.Profiles, "base")
+	assert.Contains(t, cfg.Profiles, "extra")
+	assert.Contains(t, cfg.Profiles, "nested")
+
+	assert.NotNil(t, cfg.Profiles["base"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["base"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-3", *cfg.Profiles["base"].Conditions.RequiredMonitors[0].Name)
+
+	assert.NotNil(t, cfg.Profiles["extra"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["extra"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-1", *cfg.Profiles["extra"].Conditions.RequiredMonitors[0].Name)
+
+	assert.NotNil(t, cfg.Profiles["nested"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["nested"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-2", *cfg.Profiles["nested"].Conditions.RequiredMonitors[0].Name)
+}
+
+func TestInclude_RelativePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	require.NoError(t, os.Mkdir(subDir, 0755))
+
+	mainContent := `
+[general]
+destination = "/tmp/dest"
+include = "subdir/sub.toml"
+`
+	subContent := `
+[profiles.sub]
+config_file = "sub.conf" 
+conditions.required_monitors = [{name = "DP-4"}]
+
+include = "nested.toml"
+`
+	nestedContent := `
+[profiles.nested]
+config_file = "nested.conf"
+conditions.required_monitors = [{name = "DP-5"}]
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.toml"), []byte(mainContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "sub.toml"), []byte(subContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "nested.toml"), []byte(nestedContent), 0644))
+
+	// Dummy configs. 
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "sub.conf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "nested.conf"), []byte(""), 0644))
+
+	cfg, err := config.Load(filepath.Join(tmpDir, "main.toml"))
+	require.NoError(t, err)
+
+	assert.Contains(t, cfg.Profiles, "sub")
+	assert.Contains(t, cfg.Profiles, "nested")
+
+	assert.NotNil(t, cfg.Profiles["sub"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["sub"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-4", *cfg.Profiles["sub"].Conditions.RequiredMonitors[0].Name)
+
+	assert.NotNil(t, cfg.Profiles["nested"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["nested"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-5", *cfg.Profiles["nested"].Conditions.RequiredMonitors[0].Name)
+}
+
+func TestInclude_List(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainContent := `
+[general]
+destination = "/tmp/dest"
+
+include = ["part1.toml", "part2.toml"]
+`
+	part1 := `
+[profiles.p1]
+config_file = "p1.conf"
+conditions.required_monitors = [{name = "DP-6"}]
+`
+	part2 := `
+[profiles.p2]
+config_file = "p2.conf"
+conditions.required_monitors = [{name = "DP-7"}]
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.toml"), []byte(mainContent), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "part1.toml"), []byte(part1), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "part2.toml"), []byte(part2), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "p1.conf"), []byte(""), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "p2.conf"), []byte(""), 0644))
+
+	cfg, err := config.Load(filepath.Join(tmpDir, "main.toml"))
+	require.NoError(t, err)
+
+	assert.Contains(t, cfg.Profiles, "p1")
+	assert.Contains(t, cfg.Profiles, "p2")
+
+	assert.NotNil(t, cfg.Profiles["p1"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["p1"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-6", *cfg.Profiles["p1"].Conditions.RequiredMonitors[0].Name)
+
+	assert.NotNil(t, cfg.Profiles["p2"].Conditions)
+	assert.NotEmpty(t, cfg.Profiles["p2"].Conditions.RequiredMonitors)
+	assert.Equal(t, "DP-7", *cfg.Profiles["p2"].Conditions.RequiredMonitors[0].Name)
+}

--- a/internal/filewatcher/filewatcher.go
+++ b/internal/filewatcher/filewatcher.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -83,6 +84,14 @@ func (s *Service) collectPaths() []string {
 	tuiDir := s.cfg.Get().TUISection.Colors.SourceFileDir
 	if tuiDir != nil {
 		paths[*tuiDir] = struct{}{}
+	}
+
+	configDir := s.cfg.Get().ConfigDirPath
+	for _, file := range s.cfg.Get().IncludedFiles {
+		if filepath.Dir(file) == configDir {
+			continue
+		}
+		paths[file] = struct{}{}
 	}
 
 	pathsStrings := []string{}


### PR DESCRIPTION
## What does this PR do?
This change introduces the 'include' directive to the TOML configuration system, resolving https://github.com/fiffeek/hyprdynamicmonitors/issues/139. Users can now modularize their configuration by splitting profiles across multiple files.

Key implementation details:
- Implemented recursive pre-processing in 'processIncludes' to merge file content before TOML decoding.
- Supports both single strings and lists of strings for the 'include' key.
- Handles relative paths relative to the directory of the file currently being processed.
- Enforces a recursion depth limit to prevent infinite loops.
- Added comprehensive tests covering relative paths and list inclusions.
- Updated filewatcher to monitor included files for changes, triggering auto-reload.
- Code quality improvements: regex compilation optimization, better error wrapping, and constant usage.

## Why is this change important?

Makes dynamic configs more palatable when using Nix

## How to test this PR locally?
There are tests included, but you can just split your config with an include directive


## Related issues

Closes #234
