### PR TITLE
Add line_power_AC0 to the recognized device list.

### DIFF
--- a/internal/utils/power.go
+++ b/internal/utils/power.go
@@ -13,6 +13,7 @@ import (
 
 var preferredSuffixes = []string{
 	"line_power_AC",
+	"line_power_AC0",
 	"line_power_ACAD",
 	"line_power_ADP1",
 	"line_power_Mains",


### PR DESCRIPTION
## What does this PR do?

It adds line_power_AC0 to the recognized device list in `power.go`

## Why is this change important?

discovered upon running `upower -e` that my device is not on the recognized device list:

``` 
/org/freedesktop/UPower/devices/battery_BAT0
/org/freedesktop/UPower/devices/line_power_AC0
/org/freedesktop/UPower/devices/DisplayDevice
```

Hopeful this will help others in not having to override the power device in the configuration file 

## How to test this PR locally?

Assuming the same device name in upower, run `hyprdynamicmonitors` and look for warnings/errors.

## Related issues

#105 has a similar device.