### PR TITLE
fix(tui): fix panic for appling missing profile

### DIFF
--- a/internal/tui/hdm_config_pane.go
+++ b/internal/tui/hdm_config_pane.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -122,8 +123,13 @@ func (h *HDMConfigPane) Update(msg tea.Msg) tea.Cmd {
 			logrus.Debug("Creating a new config")
 			cmds = append(cmds, profileNameToogled())
 		case key.Matches(msg, h.keymap.ApplyProfile):
-			logrus.Debug("Editing existing config")
-			cmds = append(cmds, editProfileConfirmationCmd(h.profile.Profile.Name))
+			if h.profile == nil {
+				logrus.Debug("No profile to apply")
+				cmds = append(cmds, OperationStatusCmd(OperationNameApplyProfile, errors.New("profile missing")))
+			} else {
+				logrus.Debug("Editing existing config")
+				cmds = append(cmds, editProfileConfirmationCmd(h.profile.Profile.Name))
+			}
 		case key.Matches(msg, h.keymap.EditorEdit):
 			cmds = append(cmds, openEditor(h.profile.Profile.ConfigFile))
 		case key.Matches(msg, h.keymap.RenderProfile):

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -109,6 +109,7 @@ const (
 	OperationNameCreateProfile
 	OperationNameMatchingProfile
 	OperationNameEditProfile
+	OperationNameApplyProfile
 	OperationNameHDMConfigReloadRequested
 	OperationNameNextBitdepth
 	OperationNameSetColorPreset
@@ -160,6 +161,8 @@ func (o OperationStatus) String() string {
 		operationName = "Reload Profile"
 	case OperationNameEditProfile:
 		operationName = "Edit Profile"
+	case OperationNameApplyProfile:
+		operationName = "Apply Profile"
 	case OperationNameHDMConfigReloadRequested:
 		operationName = "HDM Config Reload"
 	case OperationNameNextBitdepth:


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI crash, when trying to "apply monitors to existing profile", when no initial profile has been made.

Error messages might not be perfect, I'm open for input. :)

## Why is this change important?

Crash bad.

## How to test this PR locally?

While unit tests had not been made, you can test by opening tui with empty config, and trying to "apply monitors to existing profile". It should give the user a useful error message: "Apply Profile: profile missing".

```
touch empty.conf
hyprdynamicmonitors tui --config empty.conf
```

## Related issues

#133